### PR TITLE
Initialised the CGIAR IDO to SDG mapping 

### DIFF
--- a/src/imports/iao_terms.txt
+++ b/src/imports/iao_terms.txt
@@ -1,3 +1,4 @@
+http://purl.obolibrary.org/obo/IAO_0100001 # term replaced by
 http://purl.obolibrary.org/obo/IAO_0000005 # objective specification
 http://purl.obolibrary.org/obo/IAO_0000007 # action specification
 http://purl.obolibrary.org/obo/IAO_0000027 # data item

--- a/src/imports/sdgio_indicator_values_import.ttl
+++ b/src/imports/sdgio_indicator_values_import.ttl
@@ -4,1892 +4,1894 @@
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@base <http://purl.unep.org/sdg/imports/sdgio_indicator_values_import.ttl> .
 
-<http://purl.unep.org/sdg/imports/sdgio_indicator_values_import.ttl> rdf:type owl:Ontology .
-
-#################################################################
-#    Annotation properties
-#################################################################
-
-###  http://purl.unep.org/sdg/SDGIO_00000227
-<http://purl.unep.org/sdg/SDGIO_00000227> rdf:type owl:AnnotationProperty ;
-                                          rdfs:label "UNSD SDG indicator code" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00000242
-<http://purl.unep.org/sdg/SDGIO_00000242> rdf:type owl:AnnotationProperty ;
-                                          rdfs:label "UN SDG Indicator ID" .
-
-
-#################################################################
-#    Classes
-#################################################################
-
-###  http://purl.unep.org/sdg/SDGIO_00000003
-<http://purl.unep.org/sdg/SDGIO_00000003> rdf:type owl:Class .
-
-###  http://purl.unep.org/sdg/SDGIO_00020000
-<http://purl.unep.org/sdg/SDGIO_00020000> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C010101" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "1.1.1" ;
-                                          rdfs:label "Proportion of population below the international poverty line, by sex, age, employment status and geographical location (urban/rural)" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020001
-<http://purl.unep.org/sdg/SDGIO_00020001> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C010201" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "1.2.1" ;
-                                          rdfs:label "Proportion of population living below the national poverty line, by sex and age" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020002
-<http://purl.unep.org/sdg/SDGIO_00020002> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C010202" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "1.2.2" ;
-                                          rdfs:label "Proportion of men, women and children of all ages living in poverty in all its dimensions according to national definitions" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020003
-<http://purl.unep.org/sdg/SDGIO_00020003> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C010301" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "1.3.1" ;
-                                          rdfs:label "Proportion of population covered by social protection floors/systems, by sex, distinguishing children, unemployed persons, older persons, persons with disabilities, pregnant women, newborns, work-injury victims and the poor and the vulnerable" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020004
-<http://purl.unep.org/sdg/SDGIO_00020004> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C010401" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "1.4.1" ;
-                                          rdfs:label "Proportion of population living in households with access to basic services" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020005
-<http://purl.unep.org/sdg/SDGIO_00020005> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C010402" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "1.4.2" ;
-                                          rdfs:label "Proportion of total adult population with secure tenure rights to land, with legally recognized documentation and who perceive their rights to land as secure, by sex and by type of tenure" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020006
-<http://purl.unep.org/sdg/SDGIO_00020006> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C200303" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "1.5.1" ;
-                                          rdfs:label "Number of deaths, missing persons and directly affected persons attributed to disasters per 100,000 population" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020007
-<http://purl.unep.org/sdg/SDGIO_00020007> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C010502" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "1.5.2" ;
-                                          rdfs:label "Direct economic loss attributed to disasters in relation to global gross domestic product (GDP)" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020008
-<http://purl.unep.org/sdg/SDGIO_00020008> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C200304" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "1.5.3" ;
-                                          rdfs:label "Number of countries that adopt and implement national disaster risk reduction strategies in line with the Sendai Framework for Disaster Risk Reduction 2015-2030" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020009
-<http://purl.unep.org/sdg/SDGIO_00020009> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C200305" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "1.5.4" ;
-                                          rdfs:label "Proportion of local governments that adopt and implement local disaster risk reduction strategies in line with national disaster risk reduction strategies" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020010
-<http://purl.unep.org/sdg/SDGIO_00020010> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C010a01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "1.a.1" ;
-                                          rdfs:label "Proportion of domestically generated resources allocated by the government directly to poverty reduction programmes" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020011
-<http://purl.unep.org/sdg/SDGIO_00020011> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C010a02" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "1.a.2" ;
-                                          rdfs:label "Proportion of total government spending on essential services (education, health and social protection)" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020012
-<http://purl.unep.org/sdg/SDGIO_00020012> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C010a03" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "1.a.3" ;
-                                          rdfs:label "Sum of total grants and non-debt-creating inflows directly allocated to poverty reduction programmes as a proportion of GDP" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020013
-<http://purl.unep.org/sdg/SDGIO_00020013> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C010b01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "1.b.1" ;
-                                          rdfs:label "Proportion of government recurrent and capital spending to sectors that disproportionately benefit women, the poor and vulnerable groups" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020014
-<http://purl.unep.org/sdg/SDGIO_00020014> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C020101" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "2.1.1" ;
-                                          rdfs:label "Prevalence of undernourishment" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020015
-<http://purl.unep.org/sdg/SDGIO_00020015> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C020102" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "2.1.2" ;
-                                          rdfs:label "Prevalence of moderate or severe food insecurity in the population, based on the Food Insecurity Experience Scale (FIES)" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020016
-<http://purl.unep.org/sdg/SDGIO_00020016> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C020201" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "2.2.1" ;
-                                          rdfs:label "Prevalence of stunting (height for age <-2 standard deviation from the median of the World Health Organization (WHO) Child Growth Standards) among children under 5 years of age" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020017
-<http://purl.unep.org/sdg/SDGIO_00020017> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C020202" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "2.2.2" ;
-                                          rdfs:label "Prevalence of malnutrition (weight for height >+2 or <-2 standard deviation from the median of the WHO Child Growth Standards) among children under 5 years of age, by type (wasting and overweight)" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020018
-<http://purl.unep.org/sdg/SDGIO_00020018> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C020301" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "2.3.1" ;
-                                          rdfs:label "Volume of production per labour unit by classes of farming/pastoral/forestry enterprise size" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020019
-<http://purl.unep.org/sdg/SDGIO_00020019> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C020302" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "2.3.2" ;
-                                          rdfs:label "Average income of small-scale food producers, by sex and indigenous status" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020020
-<http://purl.unep.org/sdg/SDGIO_00020020> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C020401" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "2.4.1" ;
-                                          rdfs:label "Proportion of agricultural area under productive and sustainable agriculture" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020021
-<http://purl.unep.org/sdg/SDGIO_00020021> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C020501" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "2.5.1" ;
-                                          rdfs:label "Number of plant and animal genetic resources for food and agriculture secured in either medium or long-term conservation facilities" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020022
-<http://purl.unep.org/sdg/SDGIO_00020022> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C020502" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "2.5.2" ;
-                                          rdfs:label "Proportion of local breeds classified as being at risk, not-at-risk or at unknown level of risk of extinction" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020023
-<http://purl.unep.org/sdg/SDGIO_00020023> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C020a01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "2.a.1" ;
-                                          rdfs:label "The agriculture orientation index for government expenditures" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020024
-<http://purl.unep.org/sdg/SDGIO_00020024> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C020a02" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "2.a.2" ;
-                                          rdfs:label "Total official flows (official development assistance plus other official flows) to the agriculture sector" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020025
-<http://purl.unep.org/sdg/SDGIO_00020025> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C020b02" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "2.b.1" ;
-                                          rdfs:label "Agricultural export subsidies" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020026
-<http://purl.unep.org/sdg/SDGIO_00020026> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C020c01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "2.c.1" ;
-                                          rdfs:label "Indicator of food price anomalies" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020027
-<http://purl.unep.org/sdg/SDGIO_00020027> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C030101" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "3.1.1" ;
-                                          rdfs:label "Maternal mortality ratio" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020028
-<http://purl.unep.org/sdg/SDGIO_00020028> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C030102" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "3.1.2" ;
-                                          rdfs:label "Proportion of births attended by skilled health personnel" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020029
-<http://purl.unep.org/sdg/SDGIO_00020029> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C030201" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "3.2.1" ;
-                                          rdfs:label "Under-five mortality rate" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020030
-<http://purl.unep.org/sdg/SDGIO_00020030> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C030202" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "3.2.2" ;
-                                          rdfs:label "Neonatal mortality rate" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020031
-<http://purl.unep.org/sdg/SDGIO_00020031> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C030301" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "3.3.1" ;
-                                          rdfs:label "Number of new HIV infections per 1,000 uninfected population, by sex, age and key populations" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020032
-<http://purl.unep.org/sdg/SDGIO_00020032> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C030302" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "3.3.2" ;
-                                          rdfs:label "Tuberculosis incidence per 100,000 population" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020033
-<http://purl.unep.org/sdg/SDGIO_00020033> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C030303" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "3.3.3" ;
-                                          rdfs:label "Malaria incidence per 1,000 population" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020034
-<http://purl.unep.org/sdg/SDGIO_00020034> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C030304" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "3.3.4" ;
-                                          rdfs:label "Hepatitis B incidence per 100,000 population" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020035
-<http://purl.unep.org/sdg/SDGIO_00020035> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C030305" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "3.3.5" ;
-                                          rdfs:label "Number of people requiring interventions against neglected tropical diseases" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020036
-<http://purl.unep.org/sdg/SDGIO_00020036> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C030401" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "3.4.1" ;
-                                          rdfs:label "Mortality rate attributed to cardiovascular disease, cancer, diabetes or chronic respiratory disease" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020037
-<http://purl.unep.org/sdg/SDGIO_00020037> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C030402" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "3.4.2" ;
-                                          rdfs:label "Suicide mortality rate" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020038
-<http://purl.unep.org/sdg/SDGIO_00020038> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C030501" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "3.5.1" ;
-                                          rdfs:label "Coverage of treatment interventions (pharmacological, psychosocial and rehabilitation and aftercare services) for substance use disorders" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020039
-<http://purl.unep.org/sdg/SDGIO_00020039> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C030502" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "3.5.2" ;
-                                          rdfs:label "Harmful use of alcohol, defined according to the national context as alcohol per capita consumption (aged 15 years and older) within a calendar year in litres of pure alcohol" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020040
-<http://purl.unep.org/sdg/SDGIO_00020040> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C030601" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "3.6.1" ;
-                                          rdfs:label "Death rate due to road traffic injuries" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020041
-<http://purl.unep.org/sdg/SDGIO_00020041> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C030701" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "3.7.1" ;
-                                          rdfs:label "Proportion of women of reproductive age (aged 15-49 years) who have their need for family planning satisfied with modern methods" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020042
-<http://purl.unep.org/sdg/SDGIO_00020042> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C030702" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "3.7.2" ;
-                                          rdfs:label "Adolescent birth rate (aged 10-14 years; aged 15-19 years) per 1,000 women in that age group" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020043
-<http://purl.unep.org/sdg/SDGIO_00020043> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C030801" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "3.8.1" ;
-                                          rdfs:label "Coverage of essential health services (defined as the average coverage of essential services based on tracer interventions that include reproductive, maternal, newborn and child health, infectious diseases, non-communicable diseases and service capacity and access, among the general and the most disadvantaged population)" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020044
-<http://purl.unep.org/sdg/SDGIO_00020044> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C030802" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "3.8.2" ;
-                                          rdfs:label "Proportion of population with large household expenditures on health as a share of total household expenditure or income" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020045
-<http://purl.unep.org/sdg/SDGIO_00020045> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C030901" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "3.9.1" ;
-                                          rdfs:label "Mortality rate attributed to household and ambient air pollution" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020046
-<http://purl.unep.org/sdg/SDGIO_00020046> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C030902" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "3.9.2" ;
-                                          rdfs:label "Mortality rate attributed to unsafe water, unsafe sanitation and lack of hygiene (exposure to unsafe Water, Sanitation and Hygiene for All (WASH) services)" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020047
-<http://purl.unep.org/sdg/SDGIO_00020047> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C030903" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "3.9.3" ;
-                                          rdfs:label "Mortality rate attributed to unintentional poisoning" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020048
-<http://purl.unep.org/sdg/SDGIO_00020048> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C030a01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "3.a.1" ;
-                                          rdfs:label "Age-standardized prevalence of current tobacco use among persons aged 15 years and older" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020049
-<http://purl.unep.org/sdg/SDGIO_00020049> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C030b01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "3.b.1" ;
-                                          rdfs:label "Proportion of the target population covered by all vaccines included in their national programme" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020050
-<http://purl.unep.org/sdg/SDGIO_00020050> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C030b02" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "3.b.2" ;
-                                          rdfs:label "Total net official development assistance to medical research and basic health sectors" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020051
-<http://purl.unep.org/sdg/SDGIO_00020051> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C030b03" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "3.b.3" ;
-                                          rdfs:label "Proportion of health facilities that have a core set of relevant essential medicines available and affordable on a sustainable basis" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020052
-<http://purl.unep.org/sdg/SDGIO_00020052> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C030c01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "3.c.1" ;
-                                          rdfs:label "Health worker density and distribution" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020053
-<http://purl.unep.org/sdg/SDGIO_00020053> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C030d01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "3.d.1" ;
-                                          rdfs:label "International Health Regulations (IHR) capacity and health emergency preparedness" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020054
-<http://purl.unep.org/sdg/SDGIO_00020054> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C040101" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "4.1.1" ;
-                                          rdfs:label "Proportion of children and young people: (a) in grades 2/3; (b) at the end of primary; and (c) at the end of lower secondary achieving at least a minimum proficiency level in (i) reading and (ii) mathematics, by sex" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020055
-<http://purl.unep.org/sdg/SDGIO_00020055> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C040201" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "4.2.1" ;
-                                          rdfs:label "Proportion of children under 5 years of age who are developmentally on track in health, learning and psychosocial well-being, by sex" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020056
-<http://purl.unep.org/sdg/SDGIO_00020056> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C040202" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "4.2.2" ;
-                                          rdfs:label "Participation rate in organized learning (one year before the official primary entry age), by sex" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020057
-<http://purl.unep.org/sdg/SDGIO_00020057> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C040301" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "4.3.1" ;
-                                          rdfs:label "Participation rate of youth and adults in formal and non-formal education and training in the previous 12 months, by sex" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020058
-<http://purl.unep.org/sdg/SDGIO_00020058> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C040401" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "4.4.1" ;
-                                          rdfs:label "Proportion of youth and adults with information and communications technology (ICT) skills, by type of skill" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020059
-<http://purl.unep.org/sdg/SDGIO_00020059> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C040501" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "4.5.1" ;
-                                          rdfs:label "Parity indices (female/male, rural/urban, bottom/top wealth quintile and others such as disability status, indigenous peoples and conflict-affected, as data become available) for all education indicators on this list that can be disaggregated" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020060
-<http://purl.unep.org/sdg/SDGIO_00020060> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C040601" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "4.6.1" ;
-                                          rdfs:label "Proportion of population in a given age group achieving at least a fixed level of proficiency in functional (a) literacy and (b) numeracy skills, by sex" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020061
-<http://purl.unep.org/sdg/SDGIO_00020061> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C040701" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "4.7.1" ;
-                                          rdfs:label "Extent to which (i) global citizenship education and (ii) education for sustainable development, including gender equality and human rights, are mainstreamed at all levels in: (a) national education policies; (b) curricula; (c) teacher education; and (d) student assessment" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020062
-<http://purl.unep.org/sdg/SDGIO_00020062> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C040a01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "4.a.1" ;
-                                          rdfs:label "Proportion of schools with access to: (a) electricity; (b) the Internet for pedagogical purposes; (c) computers for pedagogical purposes; (d) adapted infrastructure and materials for students with disabilities; (e) basic drinking water; (f) single-sex basic sanitation facilities; and (g) basic handwashing facilities (as per the WASH indicator definitions)" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020063
-<http://purl.unep.org/sdg/SDGIO_00020063> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C040b01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "4.b.1" ;
-                                          rdfs:label "Volume of official development assistance flows for scholarships by sector and type of study" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020064
-<http://purl.unep.org/sdg/SDGIO_00020064> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C040c01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "4.c.1" ;
-                                          rdfs:label "Proportion of teachers in: (a) pre-primary; (b) primary; (c) lower secondary; and (d) upper secondary education who have received at least the minimum organized teacher training (e.g. pedagogical training) pre-service or in-service required for teaching at the relevant level in a given country" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020065
-<http://purl.unep.org/sdg/SDGIO_00020065> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C050101" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "5.1.1" ;
-                                          rdfs:label "Whether or not legal frameworks are in place to promote, enforce and monitor equality and non-discrimination on the basis of sex" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020066
-<http://purl.unep.org/sdg/SDGIO_00020066> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C050201" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "5.2.1" ;
-                                          rdfs:label "Proportion of ever-partnered women and girls aged 15 years and older subjected to physical, sexual or psychological violence by a current or former intimate partner in the previous 12 months, by form of violence and by age" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020067
-<http://purl.unep.org/sdg/SDGIO_00020067> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C050202" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "5.2.2" ;
-                                          rdfs:label "Proportion of women and girls aged 15 years and older subjected to sexual violence by persons other than an intimate partner in the previous 12 months, by age and place of occurrence" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020068
-<http://purl.unep.org/sdg/SDGIO_00020068> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C050301" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "5.3.1" ;
-                                          rdfs:label "Proportion of women aged 20-24 years who were married or in a union before age 15 and before age 18" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020069
-<http://purl.unep.org/sdg/SDGIO_00020069> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C050302" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "5.3.2" ;
-                                          rdfs:label "Proportion of girls and women aged 15-49 years who have undergone female genital mutilation/cutting, by age" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020070
-<http://purl.unep.org/sdg/SDGIO_00020070> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C050401" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "5.4.1" ;
-                                          rdfs:label "Proportion of time spent on unpaid domestic and care work, by sex, age and location" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020071
-<http://purl.unep.org/sdg/SDGIO_00020071> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C050501" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "5.5.1" ;
-                                          rdfs:label "Proportion of seats held by women in (a) national parliaments and (b) local governments" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020072
-<http://purl.unep.org/sdg/SDGIO_00020072> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C050502" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "5.5.2" ;
-                                          rdfs:label "Proportion of women in managerial positions" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020073
-<http://purl.unep.org/sdg/SDGIO_00020073> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C050601" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "5.6.1" ;
-                                          rdfs:label "Proportion of women aged 15-49 years who make their own informed decisions regarding sexual relations, contraceptive use and reproductive health care" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020074
-<http://purl.unep.org/sdg/SDGIO_00020074> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C050602" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "5.6.2" ;
-                                          rdfs:label "Number of countries with laws and regulations that guarantee full and equal access to women and men aged 15 years and older to sexual and reproductive health care, information and education" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020075
-<http://purl.unep.org/sdg/SDGIO_00020075> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C050a01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "5.a.1" ;
-                                          rdfs:label "(a) Proportion of total agricultural population with ownership or secure rights over agricultural land, by sex; and (b) share of women among owners or rights-bearers of agricultural land, by type of tenure" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020076
-<http://purl.unep.org/sdg/SDGIO_00020076> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C050a02" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "5.a.2" ;
-                                          rdfs:label "Proportion of countries where the legal framework (including customary law) guarantees women’s equal rights to land ownership and/or control" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020077
-<http://purl.unep.org/sdg/SDGIO_00020077> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C050b01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "5.b.1" ;
-                                          rdfs:label "Proportion of individuals who own a mobile telephone, by sex" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020078
-<http://purl.unep.org/sdg/SDGIO_00020078> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C050c01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "5.c.1" ;
-                                          rdfs:label "Proportion of countries with systems to track and make public allocations for gender equality and women’s empowerment" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020079
-<http://purl.unep.org/sdg/SDGIO_00020079> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C060101" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "6.1.1" ;
-                                          rdfs:label "Proportion of population using safely managed drinking water services" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020080
-<http://purl.unep.org/sdg/SDGIO_00020080> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C060201" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "6.2.1" ;
-                                          rdfs:label "Proportion of population using safely managed sanitation services, including a hand-washing facility with soap and water" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020081
-<http://purl.unep.org/sdg/SDGIO_00020081> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C060301" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "6.3.1" ;
-                                          rdfs:label "Proportion of wastewater safely treated" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020082
-<http://purl.unep.org/sdg/SDGIO_00020082> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C060302" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "6.3.2" ;
-                                          rdfs:label "Proportion of bodies of water with good ambient water quality" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020083
-<http://purl.unep.org/sdg/SDGIO_00020083> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C060401" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "6.4.1" ;
-                                          rdfs:label "Change in water-use efficiency over time" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020084
-<http://purl.unep.org/sdg/SDGIO_00020084> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C060402" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "6.4.2" ;
-                                          rdfs:label "Level of water stress: freshwater withdrawal as a proportion of available freshwater resources" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020085
-<http://purl.unep.org/sdg/SDGIO_00020085> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C060501" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "6.5.1" ;
-                                          rdfs:label "Degree of integrated water resources management implementation (0-100)" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020086
-<http://purl.unep.org/sdg/SDGIO_00020086> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C060502" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "6.5.2" ;
-                                          rdfs:label "Proportion of transboundary basin area with an operational arrangement for water cooperation" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020087
-<http://purl.unep.org/sdg/SDGIO_00020087> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C060601" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "6.6.1" ;
-                                          rdfs:label "Change in the extent of water-related ecosystems over time" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020088
-<http://purl.unep.org/sdg/SDGIO_00020088> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C060a01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "6.a.1" ;
-                                          rdfs:label "Amount of water- and sanitation-related official development assistance that is part of a government-coordinated spending plan" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020089
-<http://purl.unep.org/sdg/SDGIO_00020089> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C060b01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "6.b.1" ;
-                                          rdfs:label "Proportion of local administrative units with established and operational policies and procedures for participation of local communities in water and sanitation management" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020090
-<http://purl.unep.org/sdg/SDGIO_00020090> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C070101" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "7.1.1" ;
-                                          rdfs:label "Proportion of population with access to electricity" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020091
-<http://purl.unep.org/sdg/SDGIO_00020091> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C070102" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "7.1.2" ;
-                                          rdfs:label "Proportion of population with primary reliance on clean fuels and technology" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020092
-<http://purl.unep.org/sdg/SDGIO_00020092> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C070201" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "7.2.1" ;
-                                          rdfs:label "Renewable energy share in the total final energy consumption" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020093
-<http://purl.unep.org/sdg/SDGIO_00020093> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C070301" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "7.3.1" ;
-                                          rdfs:label "Energy intensity measured in terms of primary energy and GDP" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020094
-<http://purl.unep.org/sdg/SDGIO_00020094> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C070a01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "7.a.1" ;
-                                          rdfs:label "International financial flows to developing countries in support of clean energy research and development and renewable energy production, including in hybrid systems" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020095
-<http://purl.unep.org/sdg/SDGIO_00020095> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C070b01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "7.b.1" ;
-                                          rdfs:label "Investments in energy efficiency as a proportion of GDP and the amount of foreign direct investment in financial transfer for infrastructure and technology to sustainable development services" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020096
-<http://purl.unep.org/sdg/SDGIO_00020096> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C080101" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "8.1.1" ;
-                                          rdfs:label "Annual growth rate of real GDP per capita" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020097
-<http://purl.unep.org/sdg/SDGIO_00020097> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C080201" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "8.2.1" ;
-                                          rdfs:label "Annual growth rate of real GDP per employed person" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020098
-<http://purl.unep.org/sdg/SDGIO_00020098> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C080301" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "8.3.1" ;
-                                          rdfs:label "Proportion of informal employment in non‑agriculture employment, by sex" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020099
-<http://purl.unep.org/sdg/SDGIO_00020099> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C200202" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "8.4.1" ;
-                                          rdfs:label "Material footprint, material footprint per capita, and material footprint per GDP" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020100
-<http://purl.unep.org/sdg/SDGIO_00020100> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C200203" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "8.4.2" ;
-                                          rdfs:label "Domestic material consumption, domestic material consumption per capita, and domestic material consumption per GDP" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020101
-<http://purl.unep.org/sdg/SDGIO_00020101> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C080501" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "8.5.1" ;
-                                          rdfs:label "Average hourly earnings of female and male employees, by occupation, age and persons with disabilities" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020102
-<http://purl.unep.org/sdg/SDGIO_00020102> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C080502" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "8.5.2" ;
-                                          rdfs:label "Unemployment rate, by sex, age and persons with disabilities" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020103
-<http://purl.unep.org/sdg/SDGIO_00020103> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C080601" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "8.6.1" ;
-                                          rdfs:label "Proportion of youth (aged 15-24 years) not in education, employment or training" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020104
-<http://purl.unep.org/sdg/SDGIO_00020104> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C080701" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "8.7.1" ;
-                                          rdfs:label "Proportion and number of children aged 5‑17 years engaged in child labour, by sex and age" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020105
-<http://purl.unep.org/sdg/SDGIO_00020105> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C080801" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "8.8.1" ;
-                                          rdfs:label "Frequency rates of fatal and non-fatal occupational injuries, by sex and migrant status" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020106
-<http://purl.unep.org/sdg/SDGIO_00020106> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C080802" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "8.8.2" ;
-                                          rdfs:label "Level of national compliance of labour rights (freedom of association and collective bargaining) based on International Labour Organization (ILO) textual sources and national legislation, by sex and migrant status" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020107
-<http://purl.unep.org/sdg/SDGIO_00020107> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C080901" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "8.9.1" ;
-                                          rdfs:label "Tourism direct GDP as a proportion of total GDP and in growth rate" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020108
-<http://purl.unep.org/sdg/SDGIO_00020108> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C080902" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "8.9.2" ;
-                                          rdfs:label "Proportion of jobs in sustainable tourism industries out of total tourism jobs" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020109
-<http://purl.unep.org/sdg/SDGIO_00020109> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C081001" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "8.10.1" ;
-                                          rdfs:label "(a) Number of commercial bank branches per 100,000 adults and (b) number of automated teller machines (ATMs) per 100,000 adults" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020110
-<http://purl.unep.org/sdg/SDGIO_00020110> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C081002" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "8.10.2" ;
-                                          rdfs:label "Proportion of adults (15 years and older) with an account at a bank or other financial institution or with a mobile-money-service provider" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020111
-<http://purl.unep.org/sdg/SDGIO_00020111> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C080a01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "8.a.1" ;
-                                          rdfs:label "Aid for Trade commitments and disbursements" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020112
-<http://purl.unep.org/sdg/SDGIO_00020112> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C080b01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "8.b.1" ;
-                                          rdfs:label "Existence of a developed and operationalized national strategy for youth employment, as a distinct strategy or as part of a national employment strategy" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020113
-<http://purl.unep.org/sdg/SDGIO_00020113> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C090101" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "9.1.1" ;
-                                          rdfs:label "Proportion of the rural population who live within 2 km of an all-season road" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020114
-<http://purl.unep.org/sdg/SDGIO_00020114> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C090102" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "9.1.2" ;
-                                          rdfs:label "Passenger and freight volumes, by mode of transport" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020115
-<http://purl.unep.org/sdg/SDGIO_00020115> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C090201" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "9.2.1" ;
-                                          rdfs:label "Manufacturing value added as a proportion of GDP and per capita" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020116
-<http://purl.unep.org/sdg/SDGIO_00020116> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C090202" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "9.2.2" ;
-                                          rdfs:label "Manufacturing employment as a proportion of total employment" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020117
-<http://purl.unep.org/sdg/SDGIO_00020117> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C090301" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "9.3.1" ;
-                                          rdfs:label "Proportion of small-scale industries in total industry value added" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020118
-<http://purl.unep.org/sdg/SDGIO_00020118> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C090302" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "9.3.2" ;
-                                          rdfs:label "Proportion of small-scale industries with a loan or line of credit" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020119
-<http://purl.unep.org/sdg/SDGIO_00020119> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C090401" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "9.4.1" ;
-                                          rdfs:label "CO2 emission per unit of value added" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020120
-<http://purl.unep.org/sdg/SDGIO_00020120> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C090501" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "9.5.1" ;
-                                          rdfs:label "Research and development expenditure as a proportion of GDP" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020121
-<http://purl.unep.org/sdg/SDGIO_00020121> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C090502" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "9.5.2" ;
-                                          rdfs:label "Researchers (in full-time equivalent) per million inhabitants" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020122
-<http://purl.unep.org/sdg/SDGIO_00020122> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C090a01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "9.a.1" ;
-                                          rdfs:label "Total official international support (official development assistance plus other official flows) to infrastructure" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020123
-<http://purl.unep.org/sdg/SDGIO_00020123> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C090b01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "9.b.1" ;
-                                          rdfs:label "Proportion of medium and high-tech industry value added in total value added" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020124
-<http://purl.unep.org/sdg/SDGIO_00020124> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C090c01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "9.c.1" ;
-                                          rdfs:label "Proportion of population covered by a mobile network, by technology" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020125
-<http://purl.unep.org/sdg/SDGIO_00020125> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C100101" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "10.1.1" ;
-                                          rdfs:label "Growth rates of household expenditure or income per capita among the bottom 40 per cent of the population and the total population" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020126
-<http://purl.unep.org/sdg/SDGIO_00020126> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C100201" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "10.2.1" ;
-                                          rdfs:label "Proportion of people living below 50 per cent of median income, by sex, age and persons with disabilities" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020127
-<http://purl.unep.org/sdg/SDGIO_00020127> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C200204" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "10.3.1" ;
-                                          rdfs:label "Proportion of population reporting having personally felt discriminated against or harassed in the previous 12 months on the basis of a ground of discrimination prohibited under international human rights law" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020128
-<http://purl.unep.org/sdg/SDGIO_00020128> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C100401" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "10.4.1" ;
-                                          rdfs:label "Labour share of GDP, comprising wages and social protection transfers" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020129
-<http://purl.unep.org/sdg/SDGIO_00020129> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C100501" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "10.5.1" ;
-                                          rdfs:label "Financial Soundness Indicators" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020130
-<http://purl.unep.org/sdg/SDGIO_00020130> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C200205" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "10.6.1" ;
-                                          rdfs:label "Proportion of members and voting rights of developing countries in international organizations" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020131
-<http://purl.unep.org/sdg/SDGIO_00020131> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C100701" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "10.7.1" ;
-                                          rdfs:label "Recruitment cost borne by employee as a proportion of yearly income earned in country of destination" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020132
-<http://purl.unep.org/sdg/SDGIO_00020132> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C100702" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "10.7.2" ;
-                                          rdfs:label "Number of countries that have implemented well-managed migration policies" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020133
-<http://purl.unep.org/sdg/SDGIO_00020133> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C100a01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "10.a.1" ;
-                                          rdfs:label "Proportion of tariff lines applied to imports from least developed countries and developing countries with zero-tariff" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020134
-<http://purl.unep.org/sdg/SDGIO_00020134> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C100b01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "10.b.1" ;
-                                          rdfs:label "Total resource flows for development, by recipient and donor countries and type of flow (e.g. official development assistance, foreign direct investment and other flows)" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020135
-<http://purl.unep.org/sdg/SDGIO_00020135> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C100c01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "10.c.1" ;
-                                          rdfs:label "Remittance costs as a proportion of the amount remitted" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020136
-<http://purl.unep.org/sdg/SDGIO_00020136> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C110101" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "11.1.1" ;
-                                          rdfs:label "Proportion of urban population living in slums, informal settlements or inadequate housing" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020137
-<http://purl.unep.org/sdg/SDGIO_00020137> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C110201" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "11.2.1" ;
-                                          rdfs:label "Proportion of population that has convenient access to public transport, by sex, age and persons with disabilities" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020138
-<http://purl.unep.org/sdg/SDGIO_00020138> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C110301" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "11.3.1" ;
-                                          rdfs:label "Ratio of land consumption rate to population growth rate" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020139
-<http://purl.unep.org/sdg/SDGIO_00020139> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C110302" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "11.3.2" ;
-                                          rdfs:label "Proportion of cities with a direct participation structure of civil society in urban planning and management that operate regularly and democratically" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020140
-<http://purl.unep.org/sdg/SDGIO_00020140> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C110401" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "11.4.1" ;
-                                          rdfs:label "Total expenditure (public and private) per capita spent on the preservation, protection and conservation of all cultural and natural heritage, by type of heritage (cultural, natural, mixed and World Heritage Centre designation), level of government (national, regional and local/municipal), type of expenditure (operating expenditure/investment) and type of private funding (donations in kind, private non-profit sector and sponsorship)" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020141
-<http://purl.unep.org/sdg/SDGIO_00020141> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C110502" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "11.5.2" ;
-                                          rdfs:label "Direct economic loss in relation to global GDP, damage to critical infrastructure and number of disruptions to basic services, attributed to disasters" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020142
-<http://purl.unep.org/sdg/SDGIO_00020142> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C110601" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "11.6.1" ;
-                                          rdfs:label "Proportion of urban solid waste regularly collected and with adequate final discharge out of total urban solid waste generated, by cities" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020143
-<http://purl.unep.org/sdg/SDGIO_00020143> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C110602" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "11.6.2" ;
-                                          rdfs:label "Annual mean levels of fine particulate matter (e.g. PM2.5 and PM10) in cities (population weighted)" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020144
-<http://purl.unep.org/sdg/SDGIO_00020144> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C110701" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "11.7.1" ;
-                                          rdfs:label "Average share of the built-up area of cities that is open space for public use for all, by sex, age and persons with disabilities" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020145
-<http://purl.unep.org/sdg/SDGIO_00020145> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C110702" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "11.7.2" ;
-                                          rdfs:label "Proportion of persons victim of physical or sexual harassment, by sex, age, disability status and place of occurrence, in the previous 12 months" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020146
-<http://purl.unep.org/sdg/SDGIO_00020146> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C110a01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "11.a.1" ;
-                                          rdfs:label "Proportion of population living in cities that implement urban and regional development plans integrating population projections and resource needs, by size of city" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020147
-<http://purl.unep.org/sdg/SDGIO_00020147> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C110c01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "11.c.1" ;
-                                          rdfs:label "Proportion of financial support to the least developed countries that is allocated to the construction and retrofitting of sustainable, resilient and resource-efficient buildings utilizing local materials" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020148
-<http://purl.unep.org/sdg/SDGIO_00020148> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C120101" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "12.1.1" ;
-                                          rdfs:label "Number of countries with sustainable consumption and production (SCP) national action plans or SCP mainstreamed as a priority or a target into national policies" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020149
-<http://purl.unep.org/sdg/SDGIO_00020149> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C120301" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "12.3.1" ;
-                                          rdfs:label "Global food loss index" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020150
-<http://purl.unep.org/sdg/SDGIO_00020150> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C120401" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "12.4.1" ;
-                                          rdfs:label "Number of parties to international multilateral environmental agreements on hazardous waste, and other chemicals that meet their commitments and obligations in transmitting information as required by each relevant agreement" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020151
-<http://purl.unep.org/sdg/SDGIO_00020151> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C120402" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "12.4.2" ;
-                                          rdfs:label "Hazardous waste generated per capita and proportion of hazardous waste treated, by type of treatment" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020152
-<http://purl.unep.org/sdg/SDGIO_00020152> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C120501" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "12.5.1" ;
-                                          rdfs:label "National recycling rate, tons of material recycled" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020153
-<http://purl.unep.org/sdg/SDGIO_00020153> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C120601" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "12.6.1" ;
-                                          rdfs:label "Number of companies publishing sustainability reports" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020154
-<http://purl.unep.org/sdg/SDGIO_00020154> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C120701" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "12.7.1" ;
-                                          rdfs:label "Number of countries implementing sustainable public procurement policies and action plans" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020155
-<http://purl.unep.org/sdg/SDGIO_00020155> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C120801" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "12.8.1" ;
-                                          rdfs:label "Extent to which (i) global citizenship education and (ii) education for sustainable development (including climate change education) are mainstreamed in (a) national education policies; (b) curricula; (c) teacher education; and (d) student assessment" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020156
-<http://purl.unep.org/sdg/SDGIO_00020156> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C120a01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "12.a.1" ;
-                                          rdfs:label "Amount of support to developing countries on research and development for sustainable consumption and production and environmentally sound technologies" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020157
-<http://purl.unep.org/sdg/SDGIO_00020157> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C120b01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "12.b.1" ;
-                                          rdfs:label "Number of sustainable tourism strategies or policies and implemented action plans with agreed monitoring and evaluation tools" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020158
-<http://purl.unep.org/sdg/SDGIO_00020158> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C120c01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "12.c.1" ;
-                                          rdfs:label "Amount of fossil-fuel subsidies per unit of GDP (production and consumption) and as a proportion of total national expenditure on fossil fuels" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020159
-<http://purl.unep.org/sdg/SDGIO_00020159> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C130201" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "13.2.1" ;
-                                          rdfs:label "Number of countries that have communicated the establishment or operationalization of an integrated policy/strategy/plan which increases their ability to adapt to the adverse impacts of climate change, and foster climate resilience and low greenhouse gas emissions development in a manner that does not threaten food production (including a national adaptation plan, nationally determined contribution, national communication, biennial update report or other)" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020160
-<http://purl.unep.org/sdg/SDGIO_00020160> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C130301" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "13.3.1" ;
-                                          rdfs:label "Number of countries that have integrated mitigation, adaptation, impact reduction and early warning into primary, secondary and tertiary curricula" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020161
-<http://purl.unep.org/sdg/SDGIO_00020161> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C130302" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "13.3.2" ;
-                                          rdfs:label "Number of countries that have communicated the strengthening of institutional, systemic and individual capacity-building to implement adaptation, mitigation and technology transfer, and development actions" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020162
-<http://purl.unep.org/sdg/SDGIO_00020162> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C130a01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "13.a.1" ;
-                                          rdfs:label "Mobilized amount of United States dollars per year between 2020 and 2025 accountable towards the $100 billion commitment" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020163
-<http://purl.unep.org/sdg/SDGIO_00020163> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C130b01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "13.b.1" ;
-                                          rdfs:label "Number of least developed countries and small island developing States that are receiving specialized support, and amount of support, including finance, technology and capacity-building, for mechanisms for raising capacities for effective climate change-related planning and management, including focusing on women, youth and local and marginalized communities" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020164
-<http://purl.unep.org/sdg/SDGIO_00020164> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C140101" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "14.1.1" ;
-                                          rdfs:label "Index of coastal eutrophication and floating plastic debris density" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020165
-<http://purl.unep.org/sdg/SDGIO_00020165> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C140201" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "14.2.1" ;
-                                          rdfs:label "Proportion of national exclusive economic zones managed using ecosystem-based approaches" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020166
-<http://purl.unep.org/sdg/SDGIO_00020166> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C140301" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "14.3.1" ;
-                                          rdfs:label "Average marine acidity (pH) measured at agreed suite of representative sampling stations" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020167
-<http://purl.unep.org/sdg/SDGIO_00020167> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C140401" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "14.4.1" ;
-                                          rdfs:label "Proportion of fish stocks within biologically sustainable levels" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020168
-<http://purl.unep.org/sdg/SDGIO_00020168> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C140501" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "14.5.1" ;
-                                          rdfs:label "Coverage of protected areas in relation to marine areas" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020169
-<http://purl.unep.org/sdg/SDGIO_00020169> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C140601" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "14.6.1" ;
-                                          rdfs:label "Progress by countries in the degree of implementation of international instruments aiming to combat illegal, unreported and unregulated fishing" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020170
-<http://purl.unep.org/sdg/SDGIO_00020170> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C140701" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "14.7.1" ;
-                                          rdfs:label "Sustainable fisheries as a proportion of GDP in small island developing States, least developed countries and all countries" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020171
-<http://purl.unep.org/sdg/SDGIO_00020171> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C140a01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "14.a.1" ;
-                                          rdfs:label "Proportion of total research budget allocated to research in the field of marine technology" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020172
-<http://purl.unep.org/sdg/SDGIO_00020172> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C140b01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "14.b.1" ;
-                                          rdfs:label "Progress by countries in the degree of application of a legal/regulatory/policy/institutional framework which recognizes and protects access rights for small-scale fisheries" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020173
-<http://purl.unep.org/sdg/SDGIO_00020173> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C140c01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "14.c.1" ;
-                                          rdfs:label "Number of countries making progress in ratifying, accepting and implementing through legal, policy and institutional frameworks, ocean-related instruments that implement international law, as reflected in the United Nation Convention on the Law of the Sea, for the conservation and sustainable use of the oceans and their resources" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020174
-<http://purl.unep.org/sdg/SDGIO_00020174> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C150101" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "15.1.1" ;
-                                          rdfs:label "Forest area as a proportion of total land area" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020175
-<http://purl.unep.org/sdg/SDGIO_00020175> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C150102" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "15.1.2" ;
-                                          rdfs:label "Proportion of important sites for terrestrial and freshwater biodiversity that are covered by protected areas, by ecosystem type" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020176
-<http://purl.unep.org/sdg/SDGIO_00020176> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C150201" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "15.2.1" ;
-                                          rdfs:label "Progress towards sustainable forest management" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020177
-<http://purl.unep.org/sdg/SDGIO_00020177> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C150301" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "15.3.1" ;
-                                          rdfs:label "Proportion of land that is degraded over total land area" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020178
-<http://purl.unep.org/sdg/SDGIO_00020178> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C150401" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "15.4.1" ;
-                                          rdfs:label "Coverage by protected areas of important sites for mountain biodiversity" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020179
-<http://purl.unep.org/sdg/SDGIO_00020179> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C150402" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "15.4.2" ;
-                                          rdfs:label "Mountain Green Cover Index" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020180
-<http://purl.unep.org/sdg/SDGIO_00020180> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C150501" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "15.5.1" ;
-                                          rdfs:label "Red List Index" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020181
-<http://purl.unep.org/sdg/SDGIO_00020181> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C150601" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "15.6.1" ;
-                                          rdfs:label "Number of countries that have adopted legislative, administrative and policy frameworks to ensure fair and equitable sharing of benefits" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020182
-<http://purl.unep.org/sdg/SDGIO_00020182> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C200206" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "15.7.1" ;
-                                          rdfs:label "Proportion of traded wildlife that was poached or illicitly trafficked" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020183
-<http://purl.unep.org/sdg/SDGIO_00020183> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C150801" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "15.8.1" ;
-                                          rdfs:label "Proportion of countries adopting relevant national legislation and adequately resourcing the prevention or control of invasive alien species" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020184
-<http://purl.unep.org/sdg/SDGIO_00020184> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C150901" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "15.9.1" ;
-                                          rdfs:label "Progress towards national targets established in accordance with Aichi Biodiversity Target 2 of the Strategic Plan for Biodiversity 2011-2020" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020185
-<http://purl.unep.org/sdg/SDGIO_00020185> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C200207" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "15.a.1" ;
-                                          rdfs:label "Official development assistance and public expenditure on conservation and sustainable use of biodiversity and ecosystems" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020186
-<http://purl.unep.org/sdg/SDGIO_00020186> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C160101" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "16.1.1" ;
-                                          rdfs:label "Number of victims of intentional homicide per 100,000 population, by sex and age" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020187
-<http://purl.unep.org/sdg/SDGIO_00020187> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C160102" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "16.1.2" ;
-                                          rdfs:label "Conflict-related deaths per 100,000 population, by sex, age and cause" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020188
-<http://purl.unep.org/sdg/SDGIO_00020188> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C160103" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "16.1.3" ;
-                                          rdfs:label "Proportion of population subjected to physical, psychological or sexual violence in the previous 12 months" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020189
-<http://purl.unep.org/sdg/SDGIO_00020189> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C160104" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "16.1.4" ;
-                                          rdfs:label "Proportion of population that feel safe walking alone around the area they live" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020190
-<http://purl.unep.org/sdg/SDGIO_00020190> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C160201" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "16.2.1" ;
-                                          rdfs:label "Proportion of children aged 1-17 years who experienced any physical punishment and/or psychological aggression by caregivers in the past month" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020191
-<http://purl.unep.org/sdg/SDGIO_00020191> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C160202" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "16.2.2" ;
-                                          rdfs:label "Number of victims of human trafficking per 100,000 population, by sex, age and form of exploitation" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020192
-<http://purl.unep.org/sdg/SDGIO_00020192> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C160203" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "16.2.3" ;
-                                          rdfs:label "Proportion of young women and men aged 18‑29 years who experienced sexual violence by age 18" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020193
-<http://purl.unep.org/sdg/SDGIO_00020193> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C160301" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "16.3.1" ;
-                                          rdfs:label "Proportion of victims of violence in the previous 12 months who reported their victimization to competent authorities or other officially recognized conflict resolution mechanisms" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020194
-<http://purl.unep.org/sdg/SDGIO_00020194> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C160302" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "16.3.2" ;
-                                          rdfs:label "Unsentenced detainees as a proportion of overall prison population" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020195
-<http://purl.unep.org/sdg/SDGIO_00020195> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C160401" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "16.4.1" ;
-                                          rdfs:label "Total value of inward and outward illicit financial flows (in current United States dollars)" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020196
-<http://purl.unep.org/sdg/SDGIO_00020196> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C160402" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "16.4.2" ;
-                                          rdfs:label "Proportion of seized, found or surrendered arms whose illicit origin or context has been traced or established by a competent authority in line with international instruments" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020197
-<http://purl.unep.org/sdg/SDGIO_00020197> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C160501" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "16.5.1" ;
-                                          rdfs:label "Proportion of persons who had at least one contact with a public official and who paid a bribe to a public official, or were asked for a bribe by those public officials, during the previous 12 months" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020198
-<http://purl.unep.org/sdg/SDGIO_00020198> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C160502" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "16.5.2" ;
-                                          rdfs:label "Proportion of businesses that had at least one contact with a public official and that paid a bribe to a public official, or were asked for a bribe by those public officials during the previous 12 months" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020199
-<http://purl.unep.org/sdg/SDGIO_00020199> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C160601" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "16.6.1" ;
-                                          rdfs:label "Primary government expenditures as a proportion of original approved budget, by sector (or by budget codes or similar)" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020200
-<http://purl.unep.org/sdg/SDGIO_00020200> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C160602" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "16.6.2" ;
-                                          rdfs:label "Proportion of population satisfied with their last experience of public services" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020201
-<http://purl.unep.org/sdg/SDGIO_00020201> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C160701" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "16.7.1" ;
-                                          rdfs:label "Proportions of positions (by sex, age, persons with disabilities and population groups) in public institutions (national and local legislatures, public service, and judiciary) compared to national distributions" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020202
-<http://purl.unep.org/sdg/SDGIO_00020202> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C160702" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "16.7.2" ;
-                                          rdfs:label "Proportion of population who believe decision-making is inclusive and responsive, by sex, age, disability and population group" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020203
-<http://purl.unep.org/sdg/SDGIO_00020203> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C160901" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "16.9.1" ;
-                                          rdfs:label "Proportion of children under 5 years of age whose births have been registered with a civil authority, by age" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020204
-<http://purl.unep.org/sdg/SDGIO_00020204> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C161001" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "16.10.1" ;
-                                          rdfs:label "Number of verified cases of killing, kidnapping, enforced disappearance, arbitrary detention and torture of journalists, associated media personnel, trade unionists and human rights advocates in the previous 12 months" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020205
-<http://purl.unep.org/sdg/SDGIO_00020205> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C161002" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "16.10.2" ;
-                                          rdfs:label "Number of countries that adopt and implement constitutional, statutory and/or policy guarantees for public access to information" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020206
-<http://purl.unep.org/sdg/SDGIO_00020206> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C160a01" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "16.a.1" ;
-                                          rdfs:label "Existence of independent national human rights institutions in compliance with the Paris Principles" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020207
-<http://purl.unep.org/sdg/SDGIO_00020207> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C170101" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "17.1.1" ;
-                                          rdfs:label "Total government revenue as a proportion of GDP, by source" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020208
-<http://purl.unep.org/sdg/SDGIO_00020208> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C170102" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "17.1.2" ;
-                                          rdfs:label "Proportion of domestic budget funded by domestic taxes" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020209
-<http://purl.unep.org/sdg/SDGIO_00020209> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C170201" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "17.2.1" ;
-                                          rdfs:label "Net official development assistance, total and to least developed countries, as a proportion of the Organization for Economic Cooperation and Development (OECD) Development Assistance Committee donors’ gross national income (GNI)" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020210
-<http://purl.unep.org/sdg/SDGIO_00020210> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C170301" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "17.3.1" ;
-                                          rdfs:label "Foreign direct investments (FDI), official development assistance and South-South Cooperation as a proportion of total domestic budget" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020211
-<http://purl.unep.org/sdg/SDGIO_00020211> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C170302" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "17.3.2" ;
-                                          rdfs:label "Volume of remittances (in United States dollars) as a proportion of total GDP" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020212
-<http://purl.unep.org/sdg/SDGIO_00020212> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C170401" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "17.4.1" ;
-                                          rdfs:label "Debt service as a proportion of exports of goods and services" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020213
-<http://purl.unep.org/sdg/SDGIO_00020213> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C170501" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "17.5.1" ;
-                                          rdfs:label "Number of countries that adopt and implement investment promotion regimes for least developed countries" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020214
-<http://purl.unep.org/sdg/SDGIO_00020214> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C170601" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "17.6.1" ;
-                                          rdfs:label "Number of science and/or technology cooperation agreements and programmes between countries, by type of cooperation" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020215
-<http://purl.unep.org/sdg/SDGIO_00020215> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C170602" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "17.6.2" ;
-                                          rdfs:label "Fixed Internet broadband subscriptions per 100 inhabitants, by speed" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020216
-<http://purl.unep.org/sdg/SDGIO_00020216> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C170701" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "17.7.1" ;
-                                          rdfs:label "Total amount of approved funding for developing countries to promote the development, transfer, dissemination and diffusion of environmentally sound technologies" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020217
-<http://purl.unep.org/sdg/SDGIO_00020217> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C170801" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "17.8.1" ;
-                                          rdfs:label "Proportion of individuals using the Internet" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020218
-<http://purl.unep.org/sdg/SDGIO_00020218> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C170901" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "17.9.1" ;
-                                          rdfs:label "Dollar value of financial and technical assistance (including through North-South, South-South and triangular cooperation) committed to developing countries" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020219
-<http://purl.unep.org/sdg/SDGIO_00020219> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C171001" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "17.10.1" ;
-                                          rdfs:label "Worldwide weighted tariff-average" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020220
-<http://purl.unep.org/sdg/SDGIO_00020220> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C171101" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "17.11.1" ;
-                                          rdfs:label "Developing countries’ and least developed countries’ share of global exports" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020221
-<http://purl.unep.org/sdg/SDGIO_00020221> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C171201" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "17.12.1" ;
-                                          rdfs:label "Average tariffs faced by developing countries, least developed countries and small island developing States" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020222
-<http://purl.unep.org/sdg/SDGIO_00020222> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C171301" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "17.13.1" ;
-                                          rdfs:label "Macroeconomic Dashboard" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020223
-<http://purl.unep.org/sdg/SDGIO_00020223> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C171401" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "17.14.1" ;
-                                          rdfs:label "Number of countries with mechanisms in place to enhance policy coherence of sustainable development" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020224
-<http://purl.unep.org/sdg/SDGIO_00020224> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C171501" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "17.15.1" ;
-                                          rdfs:label "Extent of use of country-owned results frameworks and planning tools by providers of development cooperation" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020225
-<http://purl.unep.org/sdg/SDGIO_00020225> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C171601" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "17.16.1" ;
-                                          rdfs:label "Number of countries reporting progress in multi-stakeholder development effectiveness monitoring frameworks that support the achievement of the sustainable development goals" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020226
-<http://purl.unep.org/sdg/SDGIO_00020226> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C171701" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "17.17.1" ;
-                                          rdfs:label "Amount of United States dollars committed to public-private and civil society partnerships" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020227
-<http://purl.unep.org/sdg/SDGIO_00020227> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C171801" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "17.18.1" ;
-                                          rdfs:label "Proportion of sustainable development indicators produced at the national level with full disaggregation when relevant to the target, in accordance with the Fundamental Principles of Official Statistics" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020228
-<http://purl.unep.org/sdg/SDGIO_00020228> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C171802" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "17.18.2" ;
-                                          rdfs:label "Number of countries that have national statistical legislation that complies with the Fundamental Principles of Official Statistics" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020229
-<http://purl.unep.org/sdg/SDGIO_00020229> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C171803" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "17.18.3" ;
-                                          rdfs:label "Number of countries with a national statistical plan that is fully funded and under implementation, by source of funding" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020230
-<http://purl.unep.org/sdg/SDGIO_00020230> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C171901" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "17.19.1" ;
-                                          rdfs:label "Dollar value of all resources made available to strengthen statistical capacity in developing countries" .
-
-
-###  http://purl.unep.org/sdg/SDGIO_00020231
-<http://purl.unep.org/sdg/SDGIO_00020231> rdf:type owl:Class ;
-                                          rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000227> "C171902" ;
-                                          <http://purl.unep.org/sdg/SDGIO_00000242> "17.19.2" ;
-                                          rdfs:label "Proportion of countries that (a) have conducted at least one population and housing census in the last 10 years; and (b) have achieved 100 per cent birth registration and 80 per cent death registration" .
-
-
-#################################################################
-#    Annotations
-#################################################################
-
-<http://purl.unep.org/sdg/SDGIO_00000241> rdfs:label "indicator has target" .
-
-
-###  Generated by the OWL API (version 4.2.6) https://github.com/owlcs/owlapi
+<http://purl.unep.org/sdg/imports/sdgio_indicator_values_import.ttl> a owl:Ontology .
+# 
+# 
+# #################################################################
+# #
+# #    Annotation properties
+# #
+# #################################################################
+# 
+# 
+# http://purl.unep.org/sdg/SDGIO_00000227
+
+<http://purl.unep.org/sdg/SDGIO_00000227> a owl:AnnotationProperty ;
+	rdfs:label "UNSD SDG indicator code" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00000242
+
+<http://purl.unep.org/sdg/SDGIO_00000242> a owl:AnnotationProperty ;
+	rdfs:label "UN SDG Indicator ID" .
+# 
+# 
+# 
+# #################################################################
+# #
+# #    Classes
+# #
+# #################################################################
+# 
+# 
+# http://purl.unep.org/sdg/SDGIO_00000003
+
+<http://purl.unep.org/sdg/SDGIO_00000003> a owl:Class .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020000
+
+<http://purl.unep.org/sdg/SDGIO_00020000> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C010101" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "1.1.1" ;
+	rdfs:label "Proportion of population below the international poverty line, by sex, age, employment status and geographical location (urban/rural)" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020001
+
+<http://purl.unep.org/sdg/SDGIO_00020001> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C010201" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "1.2.1" ;
+	rdfs:label "Proportion of population living below the national poverty line, by sex and age" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020002
+
+<http://purl.unep.org/sdg/SDGIO_00020002> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C010202" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "1.2.2" ;
+	rdfs:label "Proportion of men, women and children of all ages living in poverty in all its dimensions according to national definitions" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020003
+
+<http://purl.unep.org/sdg/SDGIO_00020003> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C010301" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "1.3.1" ;
+	rdfs:label "Proportion of population covered by social protection floors/systems, by sex, distinguishing children, unemployed persons, older persons, persons with disabilities, pregnant women, newborns, work-injury victims and the poor and the vulnerable" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020004
+
+<http://purl.unep.org/sdg/SDGIO_00020004> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C010401" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "1.4.1" ;
+	rdfs:label "Proportion of population living in households with access to basic services" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020005
+
+<http://purl.unep.org/sdg/SDGIO_00020005> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C010402" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "1.4.2" ;
+	rdfs:label "Proportion of total adult population with secure tenure rights to land, with legally recognized documentation and who perceive their rights to land as secure, by sex and by type of tenure" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020006
+
+<http://purl.unep.org/sdg/SDGIO_00020006> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C200303" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "1.5.1" ;
+	rdfs:label "Number of deaths, missing persons and directly affected persons attributed to disasters per 100,000 population" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020007
+
+<http://purl.unep.org/sdg/SDGIO_00020007> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C010502" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "1.5.2" ;
+	rdfs:label "Direct economic loss attributed to disasters in relation to global gross domestic product (GDP)" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020008
+
+<http://purl.unep.org/sdg/SDGIO_00020008> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C200304" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "1.5.3" ;
+	rdfs:label "Number of countries that adopt and implement national disaster risk reduction strategies in line with the Sendai Framework for Disaster Risk Reduction 2015-2030" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020009
+
+<http://purl.unep.org/sdg/SDGIO_00020009> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C200305" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "1.5.4" ;
+	rdfs:label "Proportion of local governments that adopt and implement local disaster risk reduction strategies in line with national disaster risk reduction strategies" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020010
+
+<http://purl.unep.org/sdg/SDGIO_00020010> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C010a01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "1.a.1" ;
+	rdfs:label "Proportion of domestically generated resources allocated by the government directly to poverty reduction programmes" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020011
+
+<http://purl.unep.org/sdg/SDGIO_00020011> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C010a02" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "1.a.2" ;
+	rdfs:label "Proportion of total government spending on essential services (education, health and social protection)" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020012
+
+<http://purl.unep.org/sdg/SDGIO_00020012> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C010a03" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "1.a.3" ;
+	rdfs:label "Sum of total grants and non-debt-creating inflows directly allocated to poverty reduction programmes as a proportion of GDP" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020013
+
+<http://purl.unep.org/sdg/SDGIO_00020013> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C010b01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "1.b.1" ;
+	rdfs:label "Proportion of government recurrent and capital spending to sectors that disproportionately benefit women, the poor and vulnerable groups" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020014
+
+<http://purl.unep.org/sdg/SDGIO_00020014> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C020101" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "2.1.1" ;
+	rdfs:label "Prevalence of undernourishment" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020015
+
+<http://purl.unep.org/sdg/SDGIO_00020015> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C020102" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "2.1.2" ;
+	rdfs:label "Prevalence of moderate or severe food insecurity in the population, based on the Food Insecurity Experience Scale (FIES)" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020016
+
+<http://purl.unep.org/sdg/SDGIO_00020016> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C020201" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "2.2.1" ;
+	rdfs:label "Prevalence of stunting (height for age <-2 standard deviation from the median of the World Health Organization (WHO) Child Growth Standards) among children under 5 years of age" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020017
+
+<http://purl.unep.org/sdg/SDGIO_00020017> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C020202" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "2.2.2" ;
+	rdfs:label "Prevalence of malnutrition (weight for height >+2 or <-2 standard deviation from the median of the WHO Child Growth Standards) among children under 5 years of age, by type (wasting and overweight)" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020018
+
+<http://purl.unep.org/sdg/SDGIO_00020018> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C020301" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "2.3.1" ;
+	rdfs:label "Volume of production per labour unit by classes of farming/pastoral/forestry enterprise size" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020019
+
+<http://purl.unep.org/sdg/SDGIO_00020019> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C020302" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "2.3.2" ;
+	rdfs:label "Average income of small-scale food producers, by sex and indigenous status" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020020
+
+<http://purl.unep.org/sdg/SDGIO_00020020> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C020401" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "2.4.1" ;
+	rdfs:label "Proportion of agricultural area under productive and sustainable agriculture" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020021
+
+<http://purl.unep.org/sdg/SDGIO_00020021> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C020501" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "2.5.1" ;
+	rdfs:label "Number of plant and animal genetic resources for food and agriculture secured in either medium or long-term conservation facilities" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020022
+
+<http://purl.unep.org/sdg/SDGIO_00020022> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C020502" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "2.5.2" ;
+	rdfs:label "Proportion of local breeds classified as being at risk, not-at-risk or at unknown level of risk of extinction" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020023
+
+<http://purl.unep.org/sdg/SDGIO_00020023> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C020a01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "2.a.1" ;
+	rdfs:label "The agriculture orientation index for government expenditures" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020024
+
+<http://purl.unep.org/sdg/SDGIO_00020024> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C020a02" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "2.a.2" ;
+	rdfs:label "Total official flows (official development assistance plus other official flows) to the agriculture sector" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020025
+
+<http://purl.unep.org/sdg/SDGIO_00020025> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C020b02" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "2.b.1" ;
+	rdfs:label "Agricultural export subsidies" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020026
+
+<http://purl.unep.org/sdg/SDGIO_00020026> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C020c01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "2.c.1" ;
+	rdfs:label "Indicator of food price anomalies" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020027
+
+<http://purl.unep.org/sdg/SDGIO_00020027> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C030101" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "3.1.1" ;
+	rdfs:label "Maternal mortality ratio" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020028
+
+<http://purl.unep.org/sdg/SDGIO_00020028> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C030102" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "3.1.2" ;
+	rdfs:label "Proportion of births attended by skilled health personnel" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020029
+
+<http://purl.unep.org/sdg/SDGIO_00020029> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C030201" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "3.2.1" ;
+	rdfs:label "Under-five mortality rate" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020030
+
+<http://purl.unep.org/sdg/SDGIO_00020030> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C030202" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "3.2.2" ;
+	rdfs:label "Neonatal mortality rate" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020031
+
+<http://purl.unep.org/sdg/SDGIO_00020031> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C030301" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "3.3.1" ;
+	rdfs:label "Number of new HIV infections per 1,000 uninfected population, by sex, age and key populations" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020032
+
+<http://purl.unep.org/sdg/SDGIO_00020032> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C030302" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "3.3.2" ;
+	rdfs:label "Tuberculosis incidence per 100,000 population" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020033
+
+<http://purl.unep.org/sdg/SDGIO_00020033> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C030303" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "3.3.3" ;
+	rdfs:label "Malaria incidence per 1,000 population" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020034
+
+<http://purl.unep.org/sdg/SDGIO_00020034> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C030304" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "3.3.4" ;
+	rdfs:label "Hepatitis B incidence per 100,000 population" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020035
+
+<http://purl.unep.org/sdg/SDGIO_00020035> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C030305" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "3.3.5" ;
+	rdfs:label "Number of people requiring interventions against neglected tropical diseases" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020036
+
+<http://purl.unep.org/sdg/SDGIO_00020036> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C030401" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "3.4.1" ;
+	rdfs:label "Mortality rate attributed to cardiovascular disease, cancer, diabetes or chronic respiratory disease" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020037
+
+<http://purl.unep.org/sdg/SDGIO_00020037> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C030402" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "3.4.2" ;
+	rdfs:label "Suicide mortality rate" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020038
+
+<http://purl.unep.org/sdg/SDGIO_00020038> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C030501" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "3.5.1" ;
+	rdfs:label "Coverage of treatment interventions (pharmacological, psychosocial and rehabilitation and aftercare services) for substance use disorders" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020039
+
+<http://purl.unep.org/sdg/SDGIO_00020039> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C030502" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "3.5.2" ;
+	rdfs:label "Harmful use of alcohol, defined according to the national context as alcohol per capita consumption (aged 15 years and older) within a calendar year in litres of pure alcohol" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020040
+
+<http://purl.unep.org/sdg/SDGIO_00020040> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C030601" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "3.6.1" ;
+	rdfs:label "Death rate due to road traffic injuries" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020041
+
+<http://purl.unep.org/sdg/SDGIO_00020041> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C030701" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "3.7.1" ;
+	rdfs:label "Proportion of women of reproductive age (aged 15-49 years) who have their need for family planning satisfied with modern methods" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020042
+
+<http://purl.unep.org/sdg/SDGIO_00020042> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C030702" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "3.7.2" ;
+	rdfs:label "Adolescent birth rate (aged 10-14 years; aged 15-19 years) per 1,000 women in that age group" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020043
+
+<http://purl.unep.org/sdg/SDGIO_00020043> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C030801" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "3.8.1" ;
+	rdfs:label "Coverage of essential health services (defined as the average coverage of essential services based on tracer interventions that include reproductive, maternal, newborn and child health, infectious diseases, non-communicable diseases and service capacity and access, among the general and the most disadvantaged population)" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020044
+
+<http://purl.unep.org/sdg/SDGIO_00020044> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C030802" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "3.8.2" ;
+	rdfs:label "Proportion of population with large household expenditures on health as a share of total household expenditure or income" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020045
+
+<http://purl.unep.org/sdg/SDGIO_00020045> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C030901" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "3.9.1" ;
+	rdfs:label "Mortality rate attributed to household and ambient air pollution" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020046
+
+<http://purl.unep.org/sdg/SDGIO_00020046> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C030902" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "3.9.2" ;
+	rdfs:label "Mortality rate attributed to unsafe water, unsafe sanitation and lack of hygiene (exposure to unsafe Water, Sanitation and Hygiene for All (WASH) services)" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020047
+
+<http://purl.unep.org/sdg/SDGIO_00020047> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C030903" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "3.9.3" ;
+	rdfs:label "Mortality rate attributed to unintentional poisoning" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020048
+
+<http://purl.unep.org/sdg/SDGIO_00020048> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C030a01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "3.a.1" ;
+	rdfs:label "Age-standardized prevalence of current tobacco use among persons aged 15 years and older" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020049
+
+<http://purl.unep.org/sdg/SDGIO_00020049> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C030b01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "3.b.1" ;
+	rdfs:label "Proportion of the target population covered by all vaccines included in their national programme" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020050
+
+<http://purl.unep.org/sdg/SDGIO_00020050> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C030b02" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "3.b.2" ;
+	rdfs:label "Total net official development assistance to medical research and basic health sectors" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020051
+
+<http://purl.unep.org/sdg/SDGIO_00020051> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C030b03" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "3.b.3" ;
+	rdfs:label "Proportion of health facilities that have a core set of relevant essential medicines available and affordable on a sustainable basis" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020052
+
+<http://purl.unep.org/sdg/SDGIO_00020052> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C030c01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "3.c.1" ;
+	rdfs:label "Health worker density and distribution" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020053
+
+<http://purl.unep.org/sdg/SDGIO_00020053> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C030d01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "3.d.1" ;
+	rdfs:label "International Health Regulations (IHR) capacity and health emergency preparedness" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020054
+
+<http://purl.unep.org/sdg/SDGIO_00020054> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C040101" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "4.1.1" ;
+	rdfs:label "Proportion of children and young people: (a) in grades 2/3; (b) at the end of primary; and (c) at the end of lower secondary achieving at least a minimum proficiency level in (i) reading and (ii) mathematics, by sex" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020055
+
+<http://purl.unep.org/sdg/SDGIO_00020055> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C040201" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "4.2.1" ;
+	rdfs:label "Proportion of children under 5 years of age who are developmentally on track in health, learning and psychosocial well-being, by sex" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020056
+
+<http://purl.unep.org/sdg/SDGIO_00020056> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C040202" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "4.2.2" ;
+	rdfs:label "Participation rate in organized learning (one year before the official primary entry age), by sex" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020057
+
+<http://purl.unep.org/sdg/SDGIO_00020057> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C040301" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "4.3.1" ;
+	rdfs:label "Participation rate of youth and adults in formal and non-formal education and training in the previous 12 months, by sex" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020058
+
+<http://purl.unep.org/sdg/SDGIO_00020058> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C040401" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "4.4.1" ;
+	rdfs:label "Proportion of youth and adults with information and communications technology (ICT) skills, by type of skill" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020059
+
+<http://purl.unep.org/sdg/SDGIO_00020059> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C040501" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "4.5.1" ;
+	rdfs:label "Parity indices (female/male, rural/urban, bottom/top wealth quintile and others such as disability status, indigenous peoples and conflict-affected, as data become available) for all education indicators on this list that can be disaggregated" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020060
+
+<http://purl.unep.org/sdg/SDGIO_00020060> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C040601" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "4.6.1" ;
+	rdfs:label "Proportion of population in a given age group achieving at least a fixed level of proficiency in functional (a) literacy and (b) numeracy skills, by sex" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020061
+
+<http://purl.unep.org/sdg/SDGIO_00020061> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C040701" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "4.7.1" ;
+	rdfs:label "Extent to which (i) global citizenship education and (ii) education for sustainable development, including gender equality and human rights, are mainstreamed at all levels in: (a) national education policies; (b) curricula; (c) teacher education; and (d) student assessment" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020062
+
+<http://purl.unep.org/sdg/SDGIO_00020062> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C040a01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "4.a.1" ;
+	rdfs:label "Proportion of schools with access to: (a) electricity; (b) the Internet for pedagogical purposes; (c) computers for pedagogical purposes; (d) adapted infrastructure and materials for students with disabilities; (e) basic drinking water; (f) single-sex basic sanitation facilities; and (g) basic handwashing facilities (as per the WASH indicator definitions)" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020063
+
+<http://purl.unep.org/sdg/SDGIO_00020063> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C040b01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "4.b.1" ;
+	rdfs:label "Volume of official development assistance flows for scholarships by sector and type of study" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020064
+
+<http://purl.unep.org/sdg/SDGIO_00020064> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C040c01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "4.c.1" ;
+	rdfs:label "Proportion of teachers in: (a) pre-primary; (b) primary; (c) lower secondary; and (d) upper secondary education who have received at least the minimum organized teacher training (e.g. pedagogical training) pre-service or in-service required for teaching at the relevant level in a given country" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020065
+
+<http://purl.unep.org/sdg/SDGIO_00020065> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C050101" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "5.1.1" ;
+	rdfs:label "Whether or not legal frameworks are in place to promote, enforce and monitor equality and non-discrimination on the basis of sex" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020066
+
+<http://purl.unep.org/sdg/SDGIO_00020066> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C050201" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "5.2.1" ;
+	rdfs:label "Proportion of ever-partnered women and girls aged 15 years and older subjected to physical, sexual or psychological violence by a current or former intimate partner in the previous 12 months, by form of violence and by age" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020067
+
+<http://purl.unep.org/sdg/SDGIO_00020067> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C050202" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "5.2.2" ;
+	rdfs:label "Proportion of women and girls aged 15 years and older subjected to sexual violence by persons other than an intimate partner in the previous 12 months, by age and place of occurrence" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020068
+
+<http://purl.unep.org/sdg/SDGIO_00020068> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C050301" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "5.3.1" ;
+	rdfs:label "Proportion of women aged 20-24 years who were married or in a union before age 15 and before age 18" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020069
+
+<http://purl.unep.org/sdg/SDGIO_00020069> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C050302" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "5.3.2" ;
+	rdfs:label "Proportion of girls and women aged 15-49 years who have undergone female genital mutilation/cutting, by age" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020070
+
+<http://purl.unep.org/sdg/SDGIO_00020070> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C050401" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "5.4.1" ;
+	rdfs:label "Proportion of time spent on unpaid domestic and care work, by sex, age and location" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020071
+
+<http://purl.unep.org/sdg/SDGIO_00020071> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C050501" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "5.5.1" ;
+	rdfs:label "Proportion of seats held by women in (a) national parliaments and (b) local governments" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020072
+
+<http://purl.unep.org/sdg/SDGIO_00020072> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C050502" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "5.5.2" ;
+	rdfs:label "Proportion of women in managerial positions" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020073
+
+<http://purl.unep.org/sdg/SDGIO_00020073> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C050601" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "5.6.1" ;
+	rdfs:label "Proportion of women aged 15-49 years who make their own informed decisions regarding sexual relations, contraceptive use and reproductive health care" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020074
+
+<http://purl.unep.org/sdg/SDGIO_00020074> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C050602" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "5.6.2" ;
+	rdfs:label "Number of countries with laws and regulations that guarantee full and equal access to women and men aged 15 years and older to sexual and reproductive health care, information and education" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020075
+
+<http://purl.unep.org/sdg/SDGIO_00020075> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C050a01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "5.a.1" ;
+	rdfs:label "(a) Proportion of total agricultural population with ownership or secure rights over agricultural land, by sex; and (b) share of women among owners or rights-bearers of agricultural land, by type of tenure" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020076
+
+<http://purl.unep.org/sdg/SDGIO_00020076> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C050a02" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "5.a.2" ;
+	rdfs:label "Proportion of countries where the legal framework (including customary law) guarantees women’s equal rights to land ownership and/or control" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020077
+
+<http://purl.unep.org/sdg/SDGIO_00020077> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C050b01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "5.b.1" ;
+	rdfs:label "Proportion of individuals who own a mobile telephone, by sex" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020078
+
+<http://purl.unep.org/sdg/SDGIO_00020078> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C050c01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "5.c.1" ;
+	rdfs:label "Proportion of countries with systems to track and make public allocations for gender equality and women’s empowerment" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020079
+
+<http://purl.unep.org/sdg/SDGIO_00020079> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C060101" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "6.1.1" ;
+	rdfs:label "Proportion of population using safely managed drinking water services" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020080
+
+<http://purl.unep.org/sdg/SDGIO_00020080> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C060201" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "6.2.1" ;
+	rdfs:label "Proportion of population using safely managed sanitation services, including a hand-washing facility with soap and water" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020081
+
+<http://purl.unep.org/sdg/SDGIO_00020081> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C060301" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "6.3.1" ;
+	rdfs:label "Proportion of wastewater safely treated" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020082
+
+<http://purl.unep.org/sdg/SDGIO_00020082> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C060302" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "6.3.2" ;
+	rdfs:label "Proportion of bodies of water with good ambient water quality" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020083
+
+<http://purl.unep.org/sdg/SDGIO_00020083> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C060401" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "6.4.1" ;
+	rdfs:label "Change in water-use efficiency over time" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020084
+
+<http://purl.unep.org/sdg/SDGIO_00020084> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C060402" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "6.4.2" ;
+	rdfs:label "Level of water stress: freshwater withdrawal as a proportion of available freshwater resources" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020085
+
+<http://purl.unep.org/sdg/SDGIO_00020085> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C060501" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "6.5.1" ;
+	rdfs:label "Degree of integrated water resources management implementation (0-100)" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020086
+
+<http://purl.unep.org/sdg/SDGIO_00020086> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C060502" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "6.5.2" ;
+	rdfs:label "Proportion of transboundary basin area with an operational arrangement for water cooperation" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020087
+
+<http://purl.unep.org/sdg/SDGIO_00020087> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C060601" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "6.6.1" ;
+	rdfs:label "Change in the extent of water-related ecosystems over time" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020088
+
+<http://purl.unep.org/sdg/SDGIO_00020088> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C060a01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "6.a.1" ;
+	rdfs:label "Amount of water- and sanitation-related official development assistance that is part of a government-coordinated spending plan" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020089
+
+<http://purl.unep.org/sdg/SDGIO_00020089> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C060b01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "6.b.1" ;
+	rdfs:label "Proportion of local administrative units with established and operational policies and procedures for participation of local communities in water and sanitation management" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020090
+
+<http://purl.unep.org/sdg/SDGIO_00020090> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C070101" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "7.1.1" ;
+	rdfs:label "Proportion of population with access to electricity" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020091
+
+<http://purl.unep.org/sdg/SDGIO_00020091> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C070102" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "7.1.2" ;
+	rdfs:label "Proportion of population with primary reliance on clean fuels and technology" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020092
+
+<http://purl.unep.org/sdg/SDGIO_00020092> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C070201" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "7.2.1" ;
+	rdfs:label "Renewable energy share in the total final energy consumption" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020093
+
+<http://purl.unep.org/sdg/SDGIO_00020093> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C070301" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "7.3.1" ;
+	rdfs:label "Energy intensity measured in terms of primary energy and GDP" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020094
+
+<http://purl.unep.org/sdg/SDGIO_00020094> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C070a01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "7.a.1" ;
+	rdfs:label "International financial flows to developing countries in support of clean energy research and development and renewable energy production, including in hybrid systems" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020095
+
+<http://purl.unep.org/sdg/SDGIO_00020095> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C070b01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "7.b.1" ;
+	rdfs:label "Investments in energy efficiency as a proportion of GDP and the amount of foreign direct investment in financial transfer for infrastructure and technology to sustainable development services" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020096
+
+<http://purl.unep.org/sdg/SDGIO_00020096> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C080101" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "8.1.1" ;
+	rdfs:label "Annual growth rate of real GDP per capita" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020097
+
+<http://purl.unep.org/sdg/SDGIO_00020097> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C080201" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "8.2.1" ;
+	rdfs:label "Annual growth rate of real GDP per employed person" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020098
+
+<http://purl.unep.org/sdg/SDGIO_00020098> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C080301" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "8.3.1" ;
+	rdfs:label "Proportion of informal employment in non‑agriculture employment, by sex" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020099
+
+<http://purl.unep.org/sdg/SDGIO_00020099> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C200202" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "8.4.1" ;
+	rdfs:label "Material footprint, material footprint per capita, and material footprint per GDP" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020100
+
+<http://purl.unep.org/sdg/SDGIO_00020100> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C200203" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "8.4.2" ;
+	rdfs:label "Domestic material consumption, domestic material consumption per capita, and domestic material consumption per GDP" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020101
+
+<http://purl.unep.org/sdg/SDGIO_00020101> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C080501" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "8.5.1" ;
+	rdfs:label "Average hourly earnings of female and male employees, by occupation, age and persons with disabilities" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020102
+
+<http://purl.unep.org/sdg/SDGIO_00020102> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C080502" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "8.5.2" ;
+	rdfs:label "Unemployment rate, by sex, age and persons with disabilities" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020103
+
+<http://purl.unep.org/sdg/SDGIO_00020103> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C080601" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "8.6.1" ;
+	rdfs:label "Proportion of youth (aged 15-24 years) not in education, employment or training" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020104
+
+<http://purl.unep.org/sdg/SDGIO_00020104> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C080701" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "8.7.1" ;
+	rdfs:label "Proportion and number of children aged 5‑17 years engaged in child labour, by sex and age" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020105
+
+<http://purl.unep.org/sdg/SDGIO_00020105> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C080801" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "8.8.1" ;
+	rdfs:label "Frequency rates of fatal and non-fatal occupational injuries, by sex and migrant status" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020106
+
+<http://purl.unep.org/sdg/SDGIO_00020106> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C080802" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "8.8.2" ;
+	rdfs:label "Level of national compliance of labour rights (freedom of association and collective bargaining) based on International Labour Organization (ILO) textual sources and national legislation, by sex and migrant status" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020107
+
+<http://purl.unep.org/sdg/SDGIO_00020107> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C080901" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "8.9.1" ;
+	rdfs:label "Tourism direct GDP as a proportion of total GDP and in growth rate" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020108
+
+<http://purl.unep.org/sdg/SDGIO_00020108> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C080902" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "8.9.2" ;
+	rdfs:label "Proportion of jobs in sustainable tourism industries out of total tourism jobs" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020109
+
+<http://purl.unep.org/sdg/SDGIO_00020109> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C081001" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "8.10.1" ;
+	rdfs:label "(a) Number of commercial bank branches per 100,000 adults and (b) number of automated teller machines (ATMs) per 100,000 adults" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020110
+
+<http://purl.unep.org/sdg/SDGIO_00020110> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C081002" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "8.10.2" ;
+	rdfs:label "Proportion of adults (15 years and older) with an account at a bank or other financial institution or with a mobile-money-service provider" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020111
+
+<http://purl.unep.org/sdg/SDGIO_00020111> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C080a01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "8.a.1" ;
+	rdfs:label "Aid for Trade commitments and disbursements" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020112
+
+<http://purl.unep.org/sdg/SDGIO_00020112> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C080b01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "8.b.1" ;
+	rdfs:label "Existence of a developed and operationalized national strategy for youth employment, as a distinct strategy or as part of a national employment strategy" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020113
+
+<http://purl.unep.org/sdg/SDGIO_00020113> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C090101" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "9.1.1" ;
+	rdfs:label "Proportion of the rural population who live within 2 km of an all-season road" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020114
+
+<http://purl.unep.org/sdg/SDGIO_00020114> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C090102" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "9.1.2" ;
+	rdfs:label "Passenger and freight volumes, by mode of transport" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020115
+
+<http://purl.unep.org/sdg/SDGIO_00020115> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C090201" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "9.2.1" ;
+	rdfs:label "Manufacturing value added as a proportion of GDP and per capita" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020116
+
+<http://purl.unep.org/sdg/SDGIO_00020116> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C090202" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "9.2.2" ;
+	rdfs:label "Manufacturing employment as a proportion of total employment" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020117
+
+<http://purl.unep.org/sdg/SDGIO_00020117> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C090301" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "9.3.1" ;
+	rdfs:label "Proportion of small-scale industries in total industry value added" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020118
+
+<http://purl.unep.org/sdg/SDGIO_00020118> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C090302" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "9.3.2" ;
+	rdfs:label "Proportion of small-scale industries with a loan or line of credit" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020119
+
+<http://purl.unep.org/sdg/SDGIO_00020119> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C090401" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "9.4.1" ;
+	rdfs:label "CO2 emission per unit of value added" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020120
+
+<http://purl.unep.org/sdg/SDGIO_00020120> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C090501" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "9.5.1" ;
+	rdfs:label "Research and development expenditure as a proportion of GDP" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020121
+
+<http://purl.unep.org/sdg/SDGIO_00020121> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C090502" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "9.5.2" ;
+	rdfs:label "Researchers (in full-time equivalent) per million inhabitants" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020122
+
+<http://purl.unep.org/sdg/SDGIO_00020122> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C090a01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "9.a.1" ;
+	rdfs:label "Total official international support (official development assistance plus other official flows) to infrastructure" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020123
+
+<http://purl.unep.org/sdg/SDGIO_00020123> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C090b01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "9.b.1" ;
+	rdfs:label "Proportion of medium and high-tech industry value added in total value added" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020124
+
+<http://purl.unep.org/sdg/SDGIO_00020124> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C090c01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "9.c.1" ;
+	rdfs:label "Proportion of population covered by a mobile network, by technology" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020125
+
+<http://purl.unep.org/sdg/SDGIO_00020125> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C100101" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "10.1.1" ;
+	rdfs:label "Growth rates of household expenditure or income per capita among the bottom 40 per cent of the population and the total population" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020126
+
+<http://purl.unep.org/sdg/SDGIO_00020126> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C100201" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "10.2.1" ;
+	rdfs:label "Proportion of people living below 50 per cent of median income, by sex, age and persons with disabilities" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020127
+
+<http://purl.unep.org/sdg/SDGIO_00020127> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C200204" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "10.3.1" ;
+	rdfs:label "Proportion of population reporting having personally felt discriminated against or harassed in the previous 12 months on the basis of a ground of discrimination prohibited under international human rights law" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020128
+
+<http://purl.unep.org/sdg/SDGIO_00020128> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C100401" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "10.4.1" ;
+	rdfs:label "Labour share of GDP, comprising wages and social protection transfers" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020129
+
+<http://purl.unep.org/sdg/SDGIO_00020129> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C100501" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "10.5.1" ;
+	rdfs:label "Financial Soundness Indicators" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020130
+
+<http://purl.unep.org/sdg/SDGIO_00020130> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C200205" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "10.6.1" ;
+	rdfs:label "Proportion of members and voting rights of developing countries in international organizations" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020131
+
+<http://purl.unep.org/sdg/SDGIO_00020131> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C100701" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "10.7.1" ;
+	rdfs:label "Recruitment cost borne by employee as a proportion of yearly income earned in country of destination" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020132
+
+<http://purl.unep.org/sdg/SDGIO_00020132> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C100702" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "10.7.2" ;
+	rdfs:label "Number of countries that have implemented well-managed migration policies" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020133
+
+<http://purl.unep.org/sdg/SDGIO_00020133> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C100a01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "10.a.1" ;
+	rdfs:label "Proportion of tariff lines applied to imports from least developed countries and developing countries with zero-tariff" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020134
+
+<http://purl.unep.org/sdg/SDGIO_00020134> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C100b01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "10.b.1" ;
+	rdfs:label "Total resource flows for development, by recipient and donor countries and type of flow (e.g. official development assistance, foreign direct investment and other flows)" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020135
+
+<http://purl.unep.org/sdg/SDGIO_00020135> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C100c01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "10.c.1" ;
+	rdfs:label "Remittance costs as a proportion of the amount remitted" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020136
+
+<http://purl.unep.org/sdg/SDGIO_00020136> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C110101" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "11.1.1" ;
+	rdfs:label "Proportion of urban population living in slums, informal settlements or inadequate housing" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020137
+
+<http://purl.unep.org/sdg/SDGIO_00020137> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C110201" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "11.2.1" ;
+	rdfs:label "Proportion of population that has convenient access to public transport, by sex, age and persons with disabilities" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020138
+
+<http://purl.unep.org/sdg/SDGIO_00020138> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C110301" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "11.3.1" ;
+	rdfs:label "Ratio of land consumption rate to population growth rate" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020139
+
+<http://purl.unep.org/sdg/SDGIO_00020139> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C110302" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "11.3.2" ;
+	rdfs:label "Proportion of cities with a direct participation structure of civil society in urban planning and management that operate regularly and democratically" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020140
+
+<http://purl.unep.org/sdg/SDGIO_00020140> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C110401" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "11.4.1" ;
+	rdfs:label "Total expenditure (public and private) per capita spent on the preservation, protection and conservation of all cultural and natural heritage, by type of heritage (cultural, natural, mixed and World Heritage Centre designation), level of government (national, regional and local/municipal), type of expenditure (operating expenditure/investment) and type of private funding (donations in kind, private non-profit sector and sponsorship)" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020141
+
+<http://purl.unep.org/sdg/SDGIO_00020141> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C110502" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "11.5.2" ;
+	rdfs:label "Direct economic loss in relation to global GDP, damage to critical infrastructure and number of disruptions to basic services, attributed to disasters" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020142
+
+<http://purl.unep.org/sdg/SDGIO_00020142> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C110601" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "11.6.1" ;
+	rdfs:label "Proportion of urban solid waste regularly collected and with adequate final discharge out of total urban solid waste generated, by cities" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020143
+
+<http://purl.unep.org/sdg/SDGIO_00020143> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C110602" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "11.6.2" ;
+	rdfs:label "Annual mean levels of fine particulate matter (e.g. PM2.5 and PM10) in cities (population weighted)" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020144
+
+<http://purl.unep.org/sdg/SDGIO_00020144> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C110701" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "11.7.1" ;
+	rdfs:label "Average share of the built-up area of cities that is open space for public use for all, by sex, age and persons with disabilities" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020145
+
+<http://purl.unep.org/sdg/SDGIO_00020145> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C110702" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "11.7.2" ;
+	rdfs:label "Proportion of persons victim of physical or sexual harassment, by sex, age, disability status and place of occurrence, in the previous 12 months" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020146
+
+<http://purl.unep.org/sdg/SDGIO_00020146> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C110a01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "11.a.1" ;
+	rdfs:label "Proportion of population living in cities that implement urban and regional development plans integrating population projections and resource needs, by size of city" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020147
+
+<http://purl.unep.org/sdg/SDGIO_00020147> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C110c01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "11.c.1" ;
+	rdfs:label "Proportion of financial support to the least developed countries that is allocated to the construction and retrofitting of sustainable, resilient and resource-efficient buildings utilizing local materials" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020148
+
+<http://purl.unep.org/sdg/SDGIO_00020148> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C120101" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "12.1.1" ;
+	rdfs:label "Number of countries with sustainable consumption and production (SCP) national action plans or SCP mainstreamed as a priority or a target into national policies" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020149
+
+<http://purl.unep.org/sdg/SDGIO_00020149> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C120301" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "12.3.1" ;
+	rdfs:label "Global food loss index" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020150
+
+<http://purl.unep.org/sdg/SDGIO_00020150> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C120401" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "12.4.1" ;
+	rdfs:label "Number of parties to international multilateral environmental agreements on hazardous waste, and other chemicals that meet their commitments and obligations in transmitting information as required by each relevant agreement" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020151
+
+<http://purl.unep.org/sdg/SDGIO_00020151> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C120402" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "12.4.2" ;
+	rdfs:label "Hazardous waste generated per capita and proportion of hazardous waste treated, by type of treatment" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020152
+
+<http://purl.unep.org/sdg/SDGIO_00020152> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C120501" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "12.5.1" ;
+	rdfs:label "National recycling rate, tons of material recycled" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020153
+
+<http://purl.unep.org/sdg/SDGIO_00020153> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C120601" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "12.6.1" ;
+	rdfs:label "Number of companies publishing sustainability reports" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020154
+
+<http://purl.unep.org/sdg/SDGIO_00020154> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C120701" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "12.7.1" ;
+	rdfs:label "Number of countries implementing sustainable public procurement policies and action plans" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020155
+
+<http://purl.unep.org/sdg/SDGIO_00020155> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C120801" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "12.8.1" ;
+	rdfs:label "Extent to which (i) global citizenship education and (ii) education for sustainable development (including climate change education) are mainstreamed in (a) national education policies; (b) curricula; (c) teacher education; and (d) student assessment" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020156
+
+<http://purl.unep.org/sdg/SDGIO_00020156> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C120a01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "12.a.1" ;
+	rdfs:label "Amount of support to developing countries on research and development for sustainable consumption and production and environmentally sound technologies" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020157
+
+<http://purl.unep.org/sdg/SDGIO_00020157> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C120b01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "12.b.1" ;
+	rdfs:label "Number of sustainable tourism strategies or policies and implemented action plans with agreed monitoring and evaluation tools" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020158
+
+<http://purl.unep.org/sdg/SDGIO_00020158> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C120c01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "12.c.1" ;
+	rdfs:label "Amount of fossil-fuel subsidies per unit of GDP (production and consumption) and as a proportion of total national expenditure on fossil fuels" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020159
+
+<http://purl.unep.org/sdg/SDGIO_00020159> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C130201" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "13.2.1" ;
+	rdfs:label "Number of countries that have communicated the establishment or operationalization of an integrated policy/strategy/plan which increases their ability to adapt to the adverse impacts of climate change, and foster climate resilience and low greenhouse gas emissions development in a manner that does not threaten food production (including a national adaptation plan, nationally determined contribution, national communication, biennial update report or other)" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020160
+
+<http://purl.unep.org/sdg/SDGIO_00020160> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C130301" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "13.3.1" ;
+	rdfs:label "Number of countries that have integrated mitigation, adaptation, impact reduction and early warning into primary, secondary and tertiary curricula" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020161
+
+<http://purl.unep.org/sdg/SDGIO_00020161> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C130302" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "13.3.2" ;
+	rdfs:label "Number of countries that have communicated the strengthening of institutional, systemic and individual capacity-building to implement adaptation, mitigation and technology transfer, and development actions" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020162
+
+<http://purl.unep.org/sdg/SDGIO_00020162> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C130a01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "13.a.1" ;
+	rdfs:label "Mobilized amount of United States dollars per year between 2020 and 2025 accountable towards the $100 billion commitment" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020163
+
+<http://purl.unep.org/sdg/SDGIO_00020163> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C130b01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "13.b.1" ;
+	rdfs:label "Number of least developed countries and small island developing States that are receiving specialized support, and amount of support, including finance, technology and capacity-building, for mechanisms for raising capacities for effective climate change-related planning and management, including focusing on women, youth and local and marginalized communities" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020164
+
+<http://purl.unep.org/sdg/SDGIO_00020164> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C140101" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "14.1.1" ;
+	rdfs:label "Index of coastal eutrophication and floating plastic debris density" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020165
+
+<http://purl.unep.org/sdg/SDGIO_00020165> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C140201" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "14.2.1" ;
+	rdfs:label "Proportion of national exclusive economic zones managed using ecosystem-based approaches" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020166
+
+<http://purl.unep.org/sdg/SDGIO_00020166> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C140301" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "14.3.1" ;
+	rdfs:label "Average marine acidity (pH) measured at agreed suite of representative sampling stations" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020167
+
+<http://purl.unep.org/sdg/SDGIO_00020167> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C140401" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "14.4.1" ;
+	rdfs:label "Proportion of fish stocks within biologically sustainable levels" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020168
+
+<http://purl.unep.org/sdg/SDGIO_00020168> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C140501" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "14.5.1" ;
+	rdfs:label "Coverage of protected areas in relation to marine areas" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020169
+
+<http://purl.unep.org/sdg/SDGIO_00020169> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C140601" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "14.6.1" ;
+	rdfs:label "Progress by countries in the degree of implementation of international instruments aiming to combat illegal, unreported and unregulated fishing" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020170
+
+<http://purl.unep.org/sdg/SDGIO_00020170> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C140701" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "14.7.1" ;
+	rdfs:label "Sustainable fisheries as a proportion of GDP in small island developing States, least developed countries and all countries" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020171
+
+<http://purl.unep.org/sdg/SDGIO_00020171> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C140a01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "14.a.1" ;
+	rdfs:label "Proportion of total research budget allocated to research in the field of marine technology" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020172
+
+<http://purl.unep.org/sdg/SDGIO_00020172> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C140b01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "14.b.1" ;
+	rdfs:label "Progress by countries in the degree of application of a legal/regulatory/policy/institutional framework which recognizes and protects access rights for small-scale fisheries" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020173
+
+<http://purl.unep.org/sdg/SDGIO_00020173> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C140c01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "14.c.1" ;
+	rdfs:label "Number of countries making progress in ratifying, accepting and implementing through legal, policy and institutional frameworks, ocean-related instruments that implement international law, as reflected in the United Nation Convention on the Law of the Sea, for the conservation and sustainable use of the oceans and their resources" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020174
+
+<http://purl.unep.org/sdg/SDGIO_00020174> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C150101" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "15.1.1" ;
+	rdfs:label "Forest area as a proportion of total land area" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020175
+
+<http://purl.unep.org/sdg/SDGIO_00020175> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C150102" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "15.1.2" ;
+	rdfs:label "Proportion of important sites for terrestrial and freshwater biodiversity that are covered by protected areas, by ecosystem type" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020176
+
+<http://purl.unep.org/sdg/SDGIO_00020176> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C150201" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "15.2.1" ;
+	rdfs:label "Progress towards sustainable forest management" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020177
+
+<http://purl.unep.org/sdg/SDGIO_00020177> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C150301" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "15.3.1" ;
+	rdfs:label "Proportion of land that is degraded over total land area" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020178
+
+<http://purl.unep.org/sdg/SDGIO_00020178> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C150401" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "15.4.1" ;
+	rdfs:label "Coverage by protected areas of important sites for mountain biodiversity" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020179
+
+<http://purl.unep.org/sdg/SDGIO_00020179> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C150402" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "15.4.2" ;
+	rdfs:label "Mountain Green Cover Index" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020180
+
+<http://purl.unep.org/sdg/SDGIO_00020180> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C150501" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "15.5.1" ;
+	rdfs:label "Red List Index" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020181
+
+<http://purl.unep.org/sdg/SDGIO_00020181> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C150601" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "15.6.1" ;
+	rdfs:label "Number of countries that have adopted legislative, administrative and policy frameworks to ensure fair and equitable sharing of benefits" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020182
+
+<http://purl.unep.org/sdg/SDGIO_00020182> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C200206" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "15.7.1" ;
+	rdfs:label "Proportion of traded wildlife that was poached or illicitly trafficked" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020183
+
+<http://purl.unep.org/sdg/SDGIO_00020183> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C150801" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "15.8.1" ;
+	rdfs:label "Proportion of countries adopting relevant national legislation and adequately resourcing the prevention or control of invasive alien species" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020184
+
+<http://purl.unep.org/sdg/SDGIO_00020184> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C150901" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "15.9.1" ;
+	rdfs:label "Progress towards national targets established in accordance with Aichi Biodiversity Target 2 of the Strategic Plan for Biodiversity 2011-2020" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020185
+
+<http://purl.unep.org/sdg/SDGIO_00020185> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C200207" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "15.a.1" ;
+	rdfs:label "Official development assistance and public expenditure on conservation and sustainable use of biodiversity and ecosystems" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020186
+
+<http://purl.unep.org/sdg/SDGIO_00020186> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C160101" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "16.1.1" ;
+	rdfs:label "Number of victims of intentional homicide per 100,000 population, by sex and age" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020187
+
+<http://purl.unep.org/sdg/SDGIO_00020187> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C160102" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "16.1.2" ;
+	rdfs:label "Conflict-related deaths per 100,000 population, by sex, age and cause" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020188
+
+<http://purl.unep.org/sdg/SDGIO_00020188> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C160103" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "16.1.3" ;
+	rdfs:label "Proportion of population subjected to physical, psychological or sexual violence in the previous 12 months" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020189
+
+<http://purl.unep.org/sdg/SDGIO_00020189> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C160104" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "16.1.4" ;
+	rdfs:label "Proportion of population that feel safe walking alone around the area they live" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020190
+
+<http://purl.unep.org/sdg/SDGIO_00020190> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C160201" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "16.2.1" ;
+	rdfs:label "Proportion of children aged 1-17 years who experienced any physical punishment and/or psychological aggression by caregivers in the past month" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020191
+
+<http://purl.unep.org/sdg/SDGIO_00020191> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C160202" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "16.2.2" ;
+	rdfs:label "Number of victims of human trafficking per 100,000 population, by sex, age and form of exploitation" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020192
+
+<http://purl.unep.org/sdg/SDGIO_00020192> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C160203" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "16.2.3" ;
+	rdfs:label "Proportion of young women and men aged 18‑29 years who experienced sexual violence by age 18" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020193
+
+<http://purl.unep.org/sdg/SDGIO_00020193> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C160301" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "16.3.1" ;
+	rdfs:label "Proportion of victims of violence in the previous 12 months who reported their victimization to competent authorities or other officially recognized conflict resolution mechanisms" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020194
+
+<http://purl.unep.org/sdg/SDGIO_00020194> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C160302" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "16.3.2" ;
+	rdfs:label "Unsentenced detainees as a proportion of overall prison population" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020195
+
+<http://purl.unep.org/sdg/SDGIO_00020195> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C160401" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "16.4.1" ;
+	rdfs:label "Total value of inward and outward illicit financial flows (in current United States dollars)" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020196
+
+<http://purl.unep.org/sdg/SDGIO_00020196> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C160402" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "16.4.2" ;
+	rdfs:label "Proportion of seized, found or surrendered arms whose illicit origin or context has been traced or established by a competent authority in line with international instruments" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020197
+
+<http://purl.unep.org/sdg/SDGIO_00020197> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C160501" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "16.5.1" ;
+	rdfs:label "Proportion of persons who had at least one contact with a public official and who paid a bribe to a public official, or were asked for a bribe by those public officials, during the previous 12 months" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020198
+
+<http://purl.unep.org/sdg/SDGIO_00020198> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C160502" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "16.5.2" ;
+	rdfs:label "Proportion of businesses that had at least one contact with a public official and that paid a bribe to a public official, or were asked for a bribe by those public officials during the previous 12 months" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020199
+
+<http://purl.unep.org/sdg/SDGIO_00020199> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C160601" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "16.6.1" ;
+	rdfs:label "Primary government expenditures as a proportion of original approved budget, by sector (or by budget codes or similar)" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020200
+
+<http://purl.unep.org/sdg/SDGIO_00020200> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C160602" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "16.6.2" ;
+	rdfs:label "Proportion of population satisfied with their last experience of public services" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020201
+
+<http://purl.unep.org/sdg/SDGIO_00020201> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C160701" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "16.7.1" ;
+	rdfs:label "Proportions of positions (by sex, age, persons with disabilities and population groups) in public institutions (national and local legislatures, public service, and judiciary) compared to national distributions" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020202
+
+<http://purl.unep.org/sdg/SDGIO_00020202> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C160702" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "16.7.2" ;
+	rdfs:label "Proportion of population who believe decision-making is inclusive and responsive, by sex, age, disability and population group" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020203
+
+<http://purl.unep.org/sdg/SDGIO_00020203> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C160901" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "16.9.1" ;
+	rdfs:label "Proportion of children under 5 years of age whose births have been registered with a civil authority, by age" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020204
+
+<http://purl.unep.org/sdg/SDGIO_00020204> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C161001" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "16.10.1" ;
+	rdfs:label "Number of verified cases of killing, kidnapping, enforced disappearance, arbitrary detention and torture of journalists, associated media personnel, trade unionists and human rights advocates in the previous 12 months" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020205
+
+<http://purl.unep.org/sdg/SDGIO_00020205> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C161002" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "16.10.2" ;
+	rdfs:label "Number of countries that adopt and implement constitutional, statutory and/or policy guarantees for public access to information" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020206
+
+<http://purl.unep.org/sdg/SDGIO_00020206> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C160a01" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "16.a.1" ;
+	rdfs:label "Existence of independent national human rights institutions in compliance with the Paris Principles" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020207
+
+<http://purl.unep.org/sdg/SDGIO_00020207> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C170101" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "17.1.1" ;
+	rdfs:label "Total government revenue as a proportion of GDP, by source" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020208
+
+<http://purl.unep.org/sdg/SDGIO_00020208> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C170102" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "17.1.2" ;
+	rdfs:label "Proportion of domestic budget funded by domestic taxes" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020209
+
+<http://purl.unep.org/sdg/SDGIO_00020209> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C170201" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "17.2.1" ;
+	rdfs:label "Net official development assistance, total and to least developed countries, as a proportion of the Organization for Economic Cooperation and Development (OECD) Development Assistance Committee donors’ gross national income (GNI)" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020210
+
+<http://purl.unep.org/sdg/SDGIO_00020210> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C170301" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "17.3.1" ;
+	rdfs:label "Foreign direct investments (FDI), official development assistance and South-South Cooperation as a proportion of total domestic budget" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020211
+
+<http://purl.unep.org/sdg/SDGIO_00020211> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C170302" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "17.3.2" ;
+	rdfs:label "Volume of remittances (in United States dollars) as a proportion of total GDP" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020212
+
+<http://purl.unep.org/sdg/SDGIO_00020212> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C170401" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "17.4.1" ;
+	rdfs:label "Debt service as a proportion of exports of goods and services" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020213
+
+<http://purl.unep.org/sdg/SDGIO_00020213> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C170501" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "17.5.1" ;
+	rdfs:label "Number of countries that adopt and implement investment promotion regimes for least developed countries" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020214
+
+<http://purl.unep.org/sdg/SDGIO_00020214> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C170601" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "17.6.1" ;
+	rdfs:label "Number of science and/or technology cooperation agreements and programmes between countries, by type of cooperation" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020215
+
+<http://purl.unep.org/sdg/SDGIO_00020215> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C170602" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "17.6.2" ;
+	rdfs:label "Fixed Internet broadband subscriptions per 100 inhabitants, by speed" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020216
+
+<http://purl.unep.org/sdg/SDGIO_00020216> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C170701" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "17.7.1" ;
+	rdfs:label "Total amount of approved funding for developing countries to promote the development, transfer, dissemination and diffusion of environmentally sound technologies" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020217
+
+<http://purl.unep.org/sdg/SDGIO_00020217> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C170801" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "17.8.1" ;
+	rdfs:label "Proportion of individuals using the Internet" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020218
+
+<http://purl.unep.org/sdg/SDGIO_00020218> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C170901" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "17.9.1" ;
+	rdfs:label "Dollar value of financial and technical assistance (including through North-South, South-South and triangular cooperation) committed to developing countries" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020219
+
+<http://purl.unep.org/sdg/SDGIO_00020219> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C171001" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "17.10.1" ;
+	rdfs:label "Worldwide weighted tariff-average" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020220
+
+<http://purl.unep.org/sdg/SDGIO_00020220> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C171101" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "17.11.1" ;
+	rdfs:label "Developing countries’ and least developed countries’ share of global exports" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020221
+
+<http://purl.unep.org/sdg/SDGIO_00020221> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C171201" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "17.12.1" ;
+	rdfs:label "Average tariffs faced by developing countries, least developed countries and small island developing States" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020222
+
+<http://purl.unep.org/sdg/SDGIO_00020222> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C171301" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "17.13.1" ;
+	rdfs:label "Macroeconomic Dashboard" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020223
+
+<http://purl.unep.org/sdg/SDGIO_00020223> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C171401" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "17.14.1" ;
+	rdfs:label "Number of countries with mechanisms in place to enhance policy coherence of sustainable development" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020224
+
+<http://purl.unep.org/sdg/SDGIO_00020224> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C171501" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "17.15.1" ;
+	rdfs:label "Extent of use of country-owned results frameworks and planning tools by providers of development cooperation" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020225
+
+<http://purl.unep.org/sdg/SDGIO_00020225> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C171601" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "17.16.1" ;
+	rdfs:label "Number of countries reporting progress in multi-stakeholder development effectiveness monitoring frameworks that support the achievement of the sustainable development goals" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020226
+
+<http://purl.unep.org/sdg/SDGIO_00020226> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C171701" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "17.17.1" ;
+	rdfs:label "Amount of United States dollars committed to public-private and civil society partnerships" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020227
+
+<http://purl.unep.org/sdg/SDGIO_00020227> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C171801" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "17.18.1" ;
+	rdfs:label "Proportion of sustainable development indicators produced at the national level with full disaggregation when relevant to the target, in accordance with the Fundamental Principles of Official Statistics" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020228
+
+<http://purl.unep.org/sdg/SDGIO_00020228> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C171802" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "17.18.2" ;
+	rdfs:label "Number of countries that have national statistical legislation that complies with the Fundamental Principles of Official Statistics" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020229
+
+<http://purl.unep.org/sdg/SDGIO_00020229> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C171803" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "17.18.3" ;
+	rdfs:label "Number of countries with a national statistical plan that is fully funded and under implementation, by source of funding" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020230
+
+<http://purl.unep.org/sdg/SDGIO_00020230> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C171901" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "17.19.1" ;
+	rdfs:label "Dollar value of all resources made available to strengthen statistical capacity in developing countries" .
+# 
+# http://purl.unep.org/sdg/SDGIO_00020231
+
+<http://purl.unep.org/sdg/SDGIO_00020231> a owl:Class ;
+	rdfs:subClassOf <http://purl.unep.org/sdg/SDGIO_00000003> ;
+	<http://purl.unep.org/sdg/SDGIO_00000227> "C171902" ;
+	<http://purl.unep.org/sdg/SDGIO_00000242> "17.19.2" ;
+	rdfs:label "Proportion of countries that (a) have conducted at least one population and housing census in the last 10 years; and (b) have achieved 100 per cent birth registration and 80 per cent death registration" .
+# 
+# Generated by the OWL API (version 4.2.6.20160910-2108) https://github.com/owlcs/owlapi

--- a/src/sdgio-edit.owl
+++ b/src/sdgio-edit.owl
@@ -68,6 +68,16 @@ Declaration(Class(<http://purl.unep.org/sdg/SDGIO_00000062>))
 Declaration(Class(<http://purl.unep.org/sdg/SDGIO_00000063>))
 Declaration(Class(<http://purl.unep.org/sdg/SDGIO_00000067>))
 Declaration(Class(<http://purl.unep.org/sdg/SDGIO_00000069>))
+Declaration(Class(<http://purl.unep.org/sdg/SDGIO_00000241>))
+Declaration(Class(<http://purl.unep.org/sdg/SDGIO_00000243>))
+Declaration(Class(<http://purl.unep.org/sdg/SDGIO_00000244>))
+Declaration(Class(<http://purl.unep.org/sdg/SDGIO_00000245>))
+Declaration(Class(<http://purl.unep.org/sdg/SDGIO_00000246>))
+Declaration(Class(<http://purl.unep.org/sdg/SDGIO_00000247>))
+Declaration(Class(<http://purl.unep.org/sdg/SDGIO_00000248>))
+Declaration(Class(<http://purl.unep.org/sdg/SDGIO_00000249>))
+Declaration(Class(<http://purl.unep.org/sdg/SDGIO_00000250>))
+Declaration(Class(<http://purl.unep.org/sdg/SDGIO_00000251>))
 Declaration(Class(<http://purl.unep.org/sdg/SDGIO_00010001>))
 Declaration(Class(<http://purl.unep.org/sdg/SDGIO_00010002>))
 Declaration(Class(<http://purl.unep.org/sdg/SDGIO_00010003>))
@@ -332,6 +342,7 @@ Declaration(NamedIndividual(<http://purl.unep.org/sdg/SDGIO_00000237>))
 Declaration(NamedIndividual(<http://purl.unep.org/sdg/SDGIO_00000238>))
 Declaration(NamedIndividual(<http://purl.unep.org/sdg/SDGIO_00000239>))
 Declaration(NamedIndividual(<http://purl.unep.org/sdg/SDGIO_00000240>))
+Declaration(NamedIndividual(<http://purl.unep.org/sdg/SDGIO_00000252>))
 Declaration(AnnotationProperty(<http://purl.obolibrary.org/obo/IAO_0000116>))
 Declaration(AnnotationProperty(<http://purl.obolibrary.org/obo/IAO_0000118>))
 Declaration(AnnotationProperty(<http://purl.obolibrary.org/obo/IAO_0000119>))
@@ -342,6 +353,8 @@ Declaration(AnnotationProperty(<http://purl.unep.org/sdg/SDGIO_00000074>))
 Declaration(AnnotationProperty(<http://purl.unep.org/sdg/SDGIO_00010032>))
 Declaration(AnnotationProperty(<http://purl.unep.org/sdg/SDGIO_00010058>))
 Declaration(AnnotationProperty(<http://purl.unep.org/sdg/SDGIO_00010069>))
+Declaration(AnnotationProperty(<http://www.geneontology.org/formats/oboInOwl#created_by>))
+Declaration(AnnotationProperty(<http://www.geneontology.org/formats/oboInOwl#creation_date>))
 ############################
 #   Annotation Properties
 ############################
@@ -806,6 +819,100 @@ AnnotationAssertion(<http://purl.unep.org/sdg/SDGIO_00000068> <http://purl.unep.
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "http://www.preventionweb.net/files/50683_oiewgreportenglish.pdf") rdfs:comment <http://purl.unep.org/sdg/SDGIO_00000069> "The definition of disaster risk reflects the concept of hazardous events and disasters as the outcome of continuously present conditions of risk. Disaster risk comprises different types of potential losses which are often difficult to quantify. Nevertheless, with knowledge of the prevailing hazards and the patterns of population and socioeconomic development, disaster risks can be assessed and mapped, in broad terms at least. It is important to consider the social and economic contexts in which disaster risks occur and that people do not necessarily share the same perceptions of risk and their underlying risk factors.")
 AnnotationAssertion(rdfs:label <http://purl.unep.org/sdg/SDGIO_00000069> "disaster risk"@en)
 SubClassOf(<http://purl.unep.org/sdg/SDGIO_00000069> <http://purl.unep.org/sdg/SDGIO_00000020>)
+
+# Class: <http://purl.unep.org/sdg/SDGIO_00000241> (investigation into the causes of insect decline)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.unep.org/sdg/SDGIO_00000241> "An investigation during which investigators aim to identify the causes for reduction in the sizes of one or more insect populations.")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000116> <http://purl.unep.org/sdg/SDGIO_00000241> "To be cross-axiomatised with PCO terms when they are established: https://github.com/PopulationAndCommunityOntology/pco/issues/68")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#created_by> <http://purl.unep.org/sdg/SDGIO_00000241> "http://orcid.org/0000-0002-4366-3088"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> <http://purl.unep.org/sdg/SDGIO_00000241> "2019-01-09T08:51:55Z"^^xsd:dateTime)
+AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#created_by> "https://orcid.org/0000-0002-9620-2832") Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "INTERNAS:WS2") Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "http://www.ufz.de/index.php?de=44296") <http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <http://purl.unep.org/sdg/SDGIO_00000241> "Ursachenklärung für das Insektensterben"@de)
+AnnotationAssertion(rdfs:label <http://purl.unep.org/sdg/SDGIO_00000241> "investigation into the causes of insect decline"@en)
+SubClassOf(<http://purl.unep.org/sdg/SDGIO_00000241> <http://purl.obolibrary.org/obo/OBI_0000066>)
+
+# Class: <http://purl.unep.org/sdg/SDGIO_00000243> (human well-being)
+
+AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "http://purl.obolibrary.org/obo/NCIT_C25178") Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "http://www.eea.europa.eu/highlights/beyond-gdp/beyond-gdp-final-technical-paper") Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "http://www.eionet.europa.eu/gemet/concept/15201") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.unep.org/sdg/SDGIO_00000243> "A disposition which inheres in a human and which is realised when that human 1) exhibits physical and psychological health 2) has access to sufficient food, water, shelter, and clothing at all times as well as a secure and adequate livelihood, goods, and services 3) is present in a physical environment conducive to human health (e.g. with air and water free from harmful pollutants) 4) interacts with other humans in a social system which promotes cohesion, mutual respect, the ability to help others and provide for children, 5) security, including secure access to natural and other resources, personal safety, and security from natural and human-made disasters and 6) freedom of choice and action, including the opportunity to express and behave according to individual values.")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#created_by> <http://purl.unep.org/sdg/SDGIO_00000243> "http://orcid.org/0000-0002-4366-3088"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> <http://purl.unep.org/sdg/SDGIO_00000243> "2019-01-03T13:24:32Z"^^xsd:dateTime)
+AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#created_by> "https://orcid.org/0000-0002-9620-2832") Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "INTERNAS:WS2") Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "http://www.ufz.de/index.php?de=44296") <http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <http://purl.unep.org/sdg/SDGIO_00000243> "Gemeinwohl"@de)
+AnnotationAssertion(rdfs:comment <http://purl.unep.org/sdg/SDGIO_00000243> "This is a very complex entity with much ambiguity and differentiation across socio-cultural groups. Much more work is needed on its ontologisation. Component 6, in particular, is typically constrained by legal or social custom.")
+AnnotationAssertion(rdfs:label <http://purl.unep.org/sdg/SDGIO_00000243> "human well-being"@en)
+SubClassOf(<http://purl.unep.org/sdg/SDGIO_00000243> <http://purl.obolibrary.org/obo/BFO_0000016>)
+SubClassOf(<http://purl.unep.org/sdg/SDGIO_00000243> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/NCBITaxon_9606>))
+
+# Class: <http://purl.unep.org/sdg/SDGIO_00000244> (human well-being credit)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.unep.org/sdg/SDGIO_00000244> "An asset which can be awarded to a legal entity in exchange for its contributions to human well-being.")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#created_by> <http://purl.unep.org/sdg/SDGIO_00000244> "http://orcid.org/0000-0002-4366-3088"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> <http://purl.unep.org/sdg/SDGIO_00000244> "2019-01-03T13:55:38Z"^^xsd:dateTime)
+AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#created_by> "https://orcid.org/0000-0002-9620-2832") Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "INTERNAS:WS2") Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "http://www.ufz.de/index.php?de=44296") <http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <http://purl.unep.org/sdg/SDGIO_00000244> "Gemeinwohlpraemie"@de)
+AnnotationAssertion(rdfs:comment <http://purl.unep.org/sdg/SDGIO_00000244> "An analogue to a carbon credit.")
+AnnotationAssertion(rdfs:label <http://purl.unep.org/sdg/SDGIO_00000244> "human well-being credit"@en)
+SubClassOf(<http://purl.unep.org/sdg/SDGIO_00000244> <http://purl.unep.org/sdg/SDGIO_00010048>)
+
+# Class: <http://purl.unep.org/sdg/SDGIO_00000245> (enhancement of human well-being)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.unep.org/sdg/SDGIO_00000245> "A process during which the well-being of one or more humans is increased.")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000116> <http://purl.unep.org/sdg/SDGIO_00000245> "The axioms on this class are simplistic at this stage - once human well-being is disaggregated, we can add more informative relations.")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#created_by> <http://purl.unep.org/sdg/SDGIO_00000245> "http://orcid.org/0000-0002-4366-3088"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> <http://purl.unep.org/sdg/SDGIO_00000245> "2019-01-03T14:04:37Z"^^xsd:dateTime)
+AnnotationAssertion(rdfs:label <http://purl.unep.org/sdg/SDGIO_00000245> "enhancement of human well-being"@en)
+SubClassOf(<http://purl.unep.org/sdg/SDGIO_00000245> <http://purl.obolibrary.org/obo/BFO_0000015>)
+SubClassOf(<http://purl.unep.org/sdg/SDGIO_00000245> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000055> <http://purl.unep.org/sdg/SDGIO_00000243>))
+SubClassOf(<http://purl.unep.org/sdg/SDGIO_00000245> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000057> <http://purl.obolibrary.org/obo/NCBITaxon_9606>))
+
+# Class: <http://purl.unep.org/sdg/SDGIO_00000246> (economic credit)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.unep.org/sdg/SDGIO_00000246> "An agreement in which the provider of goods or services trusts that the consumer will provide conmpensation at a later date.")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#created_by> <http://purl.unep.org/sdg/SDGIO_00000246> "http://orcid.org/0000-0002-4366-3088"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> <http://purl.unep.org/sdg/SDGIO_00000246> "2019-01-03T15:06:29Z"^^xsd:dateTime)
+AnnotationAssertion(rdfs:label <http://purl.unep.org/sdg/SDGIO_00000246> "economic credit"@en)
+SubClassOf(<http://purl.unep.org/sdg/SDGIO_00000246> <http://purl.unep.org/sdg/SDGIO_00010048>)
+
+# Class: <http://purl.unep.org/sdg/SDGIO_00000247> (intangible asset)
+
+AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "https://en.wikipedia.org/wiki/Intangible_asset") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.unep.org/sdg/SDGIO_00000247> "A asset which is non-monetary and without physical substance.")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#created_by> <http://purl.unep.org/sdg/SDGIO_00000247> "http://orcid.org/0000-0002-4366-3088"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> <http://purl.unep.org/sdg/SDGIO_00000247> "2019-01-03T16:22:22Z"^^xsd:dateTime)
+AnnotationAssertion(rdfs:comment <http://purl.unep.org/sdg/SDGIO_00000247> "The economic (or other) worth of intangible assets are often very hard to quantify, as their evaluation is complex.")
+AnnotationAssertion(rdfs:label <http://purl.unep.org/sdg/SDGIO_00000247> "intangible asset"@en)
+EquivalentClasses(<http://purl.unep.org/sdg/SDGIO_00000247> ObjectIntersectionOf(<http://purl.unep.org/sdg/SDGIO_00010048> ObjectComplementOf(<http://purl.obolibrary.org/obo/BFO_0000040>)))
+SubClassOf(<http://purl.unep.org/sdg/SDGIO_00000247> <http://purl.unep.org/sdg/SDGIO_00010048>)
+
+# Class: <http://purl.unep.org/sdg/SDGIO_00000248> (human capital)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#created_by> <http://purl.unep.org/sdg/SDGIO_00000248> "http://orcid.org/0000-0002-4366-3088"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> <http://purl.unep.org/sdg/SDGIO_00000248> "2019-01-03T16:22:34Z"^^xsd:dateTime)
+AnnotationAssertion(rdfs:label <http://purl.unep.org/sdg/SDGIO_00000248> "human capital"@en)
+SubClassOf(<http://purl.unep.org/sdg/SDGIO_00000248> <http://purl.unep.org/sdg/SDGIO_00000247>)
+
+# Class: <http://purl.unep.org/sdg/SDGIO_00000249> (tangible asset)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.unep.org/sdg/SDGIO_00000249> "An asset which is based on one or more material entities.")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#created_by> <http://purl.unep.org/sdg/SDGIO_00000249> "http://orcid.org/0000-0002-4366-3088"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> <http://purl.unep.org/sdg/SDGIO_00000249> "2019-01-03T17:01:11Z"^^xsd:dateTime)
+AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "https://en.wikipedia.org/wiki/Asset#Tangible_assets") rdfs:comment <http://purl.unep.org/sdg/SDGIO_00000249> "Tangible assets include currencies, buildings, real estate, vehicles, inventories, equipment, art collections, precious metals, rare-earth metals, Industrial metals, and crops.")
+AnnotationAssertion(rdfs:label <http://purl.unep.org/sdg/SDGIO_00000249> "tangible asset"@en)
+EquivalentClasses(<http://purl.unep.org/sdg/SDGIO_00000249> ObjectIntersectionOf(<http://purl.unep.org/sdg/SDGIO_00010048> ObjectMinCardinality(1 <http://purl.obolibrary.org/obo/RO_0002473> <http://purl.obolibrary.org/obo/BFO_0000040>)))
+SubClassOf(<http://purl.unep.org/sdg/SDGIO_00000249> <http://purl.unep.org/sdg/SDGIO_00010048>)
+
+# Class: <http://purl.unep.org/sdg/SDGIO_00000250> (organisational objective specification)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.unep.org/sdg/SDGIO_00000250> "An objective specification which has been adopted by an organisation.")
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.unep.org/sdg/SDGIO_00000250> "http://orcid.org/0000-0002-4366-3088"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> <http://purl.unep.org/sdg/SDGIO_00000250> "2019-04-17T11:35:22Z"^^xsd:dateTime)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.unep.org/sdg/SDGIO_00000250> "organizational objective specification")
+AnnotationAssertion(rdfs:label <http://purl.unep.org/sdg/SDGIO_00000250> "organisational objective specification"@en)
+SubClassOf(<http://purl.unep.org/sdg/SDGIO_00000250> <http://purl.obolibrary.org/obo/IAO_0000005>)
+
+# Class: <http://purl.unep.org/sdg/SDGIO_00000251> (CGIAR objective specification)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.unep.org/sdg/SDGIO_00000251> "An organisational objective specification which has been adopted by the CGIAR.")
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.unep.org/sdg/SDGIO_00000251> "http://orcid.org/0000-0002-4366-3088"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> <http://purl.unep.org/sdg/SDGIO_00000251> "2019-04-17T11:38:29Z"^^xsd:dateTime)
+AnnotationAssertion(rdfs:label <http://purl.unep.org/sdg/SDGIO_00000251> "CGIAR objective specification"@en)
+SubClassOf(<http://purl.unep.org/sdg/SDGIO_00000251> <http://purl.unep.org/sdg/SDGIO_00000250>)
 
 # Class: <http://purl.unep.org/sdg/SDGIO_00010001> (education process)
 
@@ -2566,6 +2673,14 @@ ClassAssertion(<http://purl.unep.org/sdg/SDGIO_00000001> <http://purl.unep.org/s
 AnnotationAssertion(<http://purl.unep.org/sdg/SDGIO_00000074> <http://purl.unep.org/sdg/SDGIO_00000240> "17.19")
 AnnotationAssertion(rdfs:label <http://purl.unep.org/sdg/SDGIO_00000240> "By 2030, build on existing initiatives to develop measurements of progress on sustainable development that complement gross domestic product, and support statistical capacity-building in developing countries"@en)
 ClassAssertion(<http://purl.unep.org/sdg/SDGIO_00000001> <http://purl.unep.org/sdg/SDGIO_00000240>)
+
+# Individual: <http://purl.unep.org/sdg/SDGIO_00000252> (test CGIAR IDO)
+
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.unep.org/sdg/SDGIO_00000252> "http://orcid.org/0000-0002-4366-3088"^^xsd:string)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> <http://purl.unep.org/sdg/SDGIO_00000252> "2019-04-17T11:40:33Z"^^xsd:dateTime)
+AnnotationAssertion(rdfs:comment <http://purl.unep.org/sdg/SDGIO_00000252> "This is just a placeholder to be edited/updated.")
+AnnotationAssertion(rdfs:label <http://purl.unep.org/sdg/SDGIO_00000252> "test CGIAR IDO"@en)
+ClassAssertion(<http://purl.unep.org/sdg/SDGIO_00000251> <http://purl.unep.org/sdg/SDGIO_00000252>)
 
 
 AnnotationAssertion(<http://purl.unep.org/sdg/SDGIO_00010069> <http://purl.obolibrary.org/obo/BFO_0000002> "true"^^xsd:boolean)


### PR DESCRIPTION
I've made an example of how we can add CGIAR IDOs to the SDGIO in response to #125 

I think it would make sense to create subclass of the CGIAR organisational objectives to distribute instances across. 